### PR TITLE
Allow model training with feature selection

### DIFF
--- a/aibolit/__main__.py
+++ b/aibolit/__main__.py
@@ -302,7 +302,7 @@ def inference(
         with open(model_path, 'rb') as fid:
             model = pickle.load(fid)
         sorted_result, importances = model.predict(input_params)
-        patterns_list = model.features_conf['patterns_only']
+        patterns_list = model.features_conf['features_order']
         for iter, (key, val) in enumerate(sorted_result.items()):
             if key in patterns_list:
                 pattern_code = key

--- a/test/integration/test_model.py
+++ b/test/integration/test_model.py
@@ -47,5 +47,25 @@ def test_model_training():
         shutil.rmtree(catboost_folder)
 
 
+def test_train_with_selected_features():
+    cur_file_dir = Path(os.path.realpath(__file__)).parent
+    model = PatternRankingModel()
+    selected_patterns = ['P18', 'P9', 'M2', 'M5']
+    train_df = generate_fake_dataset()
+    print('Features for the whole dataset: {}'.format(list(train_df.columns)))
+    target = train_df.pop('M4')
+    start = time()
+    print('Start training...')
+    model.fit_regressor(train_df, target, selected_patterns)
+    end = time()
+    print('End training. Elapsed time: {:.2f} secs'.format(end - start))
+    # this folder is created by catboost library, impossible to get rid of it
+    catboost_folder = Path(cur_file_dir, 'catboost_info')
+    if catboost_folder.exists():
+        shutil.rmtree(catboost_folder)
+    print('Model features: {}'.format(model.features_conf['features_order']))
+
+
 if __name__ == '__main__':
     test_model_training()
+    test_train_with_selected_features()


### PR DESCRIPTION
fix https://github.com/cqfn/aibolit/issues/574

1) request #594 has and interface to use `test` function. But we have to retrain model, since that function is not included yet in model.pkl

2) integration test is added with feature selection

3) You can use the following way:

```
    selected_patterns = ['P18', 'P9', 'M2', 'M5']
    model.fit_regressor(train_df, target, selected_patterns)
```

So, we select features we need. The model will be trained using only features which are passed to function (if we pass them), otherwise all features will be used.

See full test (test_train_with_selected_features.py) for detailed information.



