### PR TITLE
CLI app to extract semantic from methods.

### DIFF
--- a/aibolit/ast_framework/ast_node.py
+++ b/aibolit/ast_framework/ast_node.py
@@ -45,6 +45,14 @@ class ASTNode:
             yield ASTNode(self._graph, child_index)
 
     @property
+    def parent(self) -> Optional["ASTNode"]:
+        try:
+            parent_index = next(self._graph.predecessors(self._node_index))
+            return ASTNode(self._graph, parent_index)
+        except StopIteration:
+            return None
+
+    @property
     def node_index(self) -> int:
         return self._node_index
 

--- a/aibolit/extract_method_baseline/extract_semantic.py
+++ b/aibolit/extract_method_baseline/extract_semantic.py
@@ -36,26 +36,26 @@ class StatementSemantic(NamedTuple):
 def extract_method_statements_semantic(method_ast: AST) -> Dict[ASTNode, StatementSemantic]:
     statement_semantic: Dict[ASTNode, StatementSemantic] = OrderedDict()
     for statement in method_ast.get_root().body:
-        statement_semantic.update(extract_statement_semantic(statement, method_ast))
+        statement_semantic.update(_extract_statement_semantic(statement, method_ast))
 
     return statement_semantic
 
 
-def extract_statement_semantic(statement: ASTNode, method_ast: AST) -> Dict[ASTNode, StatementSemantic]:
+def _extract_statement_semantic(statement: ASTNode, method_ast: AST) -> Dict[ASTNode, StatementSemantic]:
     if statement.node_type == ASTNodeType.BLOCK_STATEMENT:
-        return extract_block_semantic(statement, method_ast)
+        return _extract_block_semantic(statement, method_ast)
     elif statement.node_type == ASTNodeType.FOR_STATEMENT:
-        return extract_for_cycle_semantic(statement, method_ast)
+        return _extract_for_cycle_semantic(statement, method_ast)
     elif statement.node_type in {ASTNodeType.DO_STATEMENT, ASTNodeType.WHILE_STATEMENT}:
-        return extract_while_cycle_semantic(statement, method_ast)
+        return _extract_while_cycle_semantic(statement, method_ast)
     elif statement.node_type == ASTNodeType.IF_STATEMENT:
-        return extract_if_branching_sematic(statement, method_ast)
+        return _extract_if_branching_sematic(statement, method_ast)
     elif statement.node_type == ASTNodeType.SYNCHRONIZED_STATEMENT:
-        return extract_synchronized_block_semantic(statement, method_ast)
+        return _extract_synchronized_block_semantic(statement, method_ast)
     elif statement.node_type == ASTNodeType.SWITCH_STATEMENT:
-        return extract_switch_branching_semantic(statement, method_ast)
+        return _extract_switch_branching_semantic(statement, method_ast)
     elif statement.node_type == ASTNodeType.TRY_STATEMENT:
-        return extract_try_block_semantic(statement, method_ast)
+        return _extract_try_block_semantic(statement, method_ast)
     elif statement.node_type in {
         ASTNodeType.ASSERT_STATEMENT,
         ASTNodeType.RETURN_STATEMENT,
@@ -63,7 +63,7 @@ def extract_statement_semantic(statement: ASTNode, method_ast: AST) -> Dict[ASTN
         ASTNodeType.THROW_STATEMENT,
         ASTNodeType.LOCAL_VARIABLE_DECLARATION,
     }:
-        return extract_plain_statement_semantic(statement, method_ast)
+        return _extract_plain_statement_semantic(statement, method_ast)
     elif statement.node_type in {
         ASTNodeType.BREAK_STATEMENT,  # Single keyword statement has no semantic
         ASTNodeType.CONTINUE_STATEMENT,  # Single keyword statement has no semantic
@@ -74,104 +74,104 @@ def extract_statement_semantic(statement: ASTNode, method_ast: AST) -> Dict[ASTN
     raise NotImplementedError(f"Extracting semantic from {statement.node_type} is not supported")
 
 
-def extract_for_cycle_semantic(statement: ASTNode, method_ast: AST) -> Dict[ASTNode, StatementSemantic]:
+def _extract_for_cycle_semantic(statement: ASTNode, method_ast: AST) -> Dict[ASTNode, StatementSemantic]:
     control_subtree = method_ast.get_subtree(statement.control)
     statements_semantic: Dict[ASTNode, StatementSemantic] = OrderedDict(
-        [(statement, extract_semantic_from_ast(control_subtree))]
+        [(statement, _extract_semantic_from_ast(control_subtree))]
     )
 
-    statements_semantic.update(extract_statement_semantic(statement.body, method_ast))
+    statements_semantic.update(_extract_statement_semantic(statement.body, method_ast))
 
     return statements_semantic
 
 
-def extract_block_semantic(statement: ASTNode, method_ast: AST) -> Dict[ASTNode, StatementSemantic]:
+def _extract_block_semantic(statement: ASTNode, method_ast: AST) -> Dict[ASTNode, StatementSemantic]:
     statements_semantic: Dict[ASTNode, StatementSemantic] = OrderedDict()
     for node in statement.statements:
-        statements_semantic.update(extract_statement_semantic(node, method_ast))
+        statements_semantic.update(_extract_statement_semantic(node, method_ast))
 
     return statements_semantic
 
 
-def extract_while_cycle_semantic(statement: ASTNode, method_ast: AST) -> Dict[ASTNode, StatementSemantic]:
+def _extract_while_cycle_semantic(statement: ASTNode, method_ast: AST) -> Dict[ASTNode, StatementSemantic]:
     condition_subtree = method_ast.get_subtree(statement.condition)
     statements_semantic: Dict[ASTNode, StatementSemantic] = OrderedDict(
-        [(statement, extract_semantic_from_ast(condition_subtree))]
+        [(statement, _extract_semantic_from_ast(condition_subtree))]
     )
 
-    statements_semantic.update(extract_statement_semantic(statement.body, method_ast))
+    statements_semantic.update(_extract_statement_semantic(statement.body, method_ast))
 
     return statements_semantic
 
 
-def extract_if_branching_sematic(statement: ASTNode, method_ast: AST) -> Dict[ASTNode, StatementSemantic]:
+def _extract_if_branching_sematic(statement: ASTNode, method_ast: AST) -> Dict[ASTNode, StatementSemantic]:
     condition_subtree = method_ast.get_subtree(statement.condition)
     statements_semantic: Dict[ASTNode, StatementSemantic] = OrderedDict(
-        [(statement, extract_semantic_from_ast(condition_subtree))]
+        [(statement, _extract_semantic_from_ast(condition_subtree))]
     )
 
-    statements_semantic.update(extract_statement_semantic(statement.then_statement, method_ast))
+    statements_semantic.update(_extract_statement_semantic(statement.then_statement, method_ast))
 
     if statement.else_statement is not None:
-        statements_semantic.update(extract_statement_semantic(statement.else_statement, method_ast))
+        statements_semantic.update(_extract_statement_semantic(statement.else_statement, method_ast))
 
     return statements_semantic
 
 
-def extract_synchronized_block_semantic(
+def _extract_synchronized_block_semantic(
     statement: ASTNode, method_ast: AST
 ) -> Dict[ASTNode, StatementSemantic]:
     lock_subtree = method_ast.get_subtree(statement.lock)
     statements_semantic: Dict[ASTNode, StatementSemantic] = OrderedDict(
-        [(statement, extract_semantic_from_ast(lock_subtree))]
+        [(statement, _extract_semantic_from_ast(lock_subtree))]
     )
 
     for inner_statement in statement.block:
-        statements_semantic.update(extract_statement_semantic(inner_statement, method_ast))
+        statements_semantic.update(_extract_statement_semantic(inner_statement, method_ast))
     return statements_semantic
 
 
-def extract_switch_branching_semantic(
+def _extract_switch_branching_semantic(
     statement: ASTNode, method_ast: AST
 ) -> Dict[ASTNode, StatementSemantic]:
     expression_subtree = method_ast.get_subtree(statement.expression)
     statements_semantic: Dict[ASTNode, StatementSemantic] = OrderedDict(
-        [(statement, extract_semantic_from_ast(expression_subtree))]
+        [(statement, _extract_semantic_from_ast(expression_subtree))]
     )
 
     for case in statement.cases:
         for inner_statement in case.statements:
-            statements_semantic.update(extract_statement_semantic(inner_statement, method_ast))
+            statements_semantic.update(_extract_statement_semantic(inner_statement, method_ast))
 
     return statements_semantic
 
 
-def extract_try_block_semantic(statement: ASTNode, method_ast: AST) -> Dict[ASTNode, StatementSemantic]:
+def _extract_try_block_semantic(statement: ASTNode, method_ast: AST) -> Dict[ASTNode, StatementSemantic]:
     statements_semantic: Dict[ASTNode, StatementSemantic] = OrderedDict()
 
     for resource in statement.resources or []:
         resource_ast = method_ast.get_subtree(resource)
-        statements_semantic[resource] = extract_semantic_from_ast(resource_ast)
+        statements_semantic[resource] = _extract_semantic_from_ast(resource_ast)
 
     for node in statement.block:
-        statements_semantic.update(extract_statement_semantic(node, method_ast))
+        statements_semantic.update(_extract_statement_semantic(node, method_ast))
 
     for catch_clause in statement.catches or []:
         for inner_statement in catch_clause.block:
-            statements_semantic.update(extract_statement_semantic(inner_statement, method_ast))
+            statements_semantic.update(_extract_statement_semantic(inner_statement, method_ast))
 
     for node in statement.finally_block or []:
-        statements_semantic.update(extract_statement_semantic(node, method_ast))
+        statements_semantic.update(_extract_statement_semantic(node, method_ast))
 
     return statements_semantic
 
 
-def extract_plain_statement_semantic(statement: ASTNode, method_ast: AST) -> Dict[ASTNode, StatementSemantic]:
+def _extract_plain_statement_semantic(statement: ASTNode, method_ast: AST) -> Dict[ASTNode, StatementSemantic]:
     statement_ast = method_ast.get_subtree(statement)
-    return OrderedDict([(statement, extract_semantic_from_ast(statement_ast))])
+    return OrderedDict([(statement, _extract_semantic_from_ast(statement_ast))])
 
 
-def extract_semantic_from_ast(statement_ast: AST) -> StatementSemantic:
+def _extract_semantic_from_ast(statement_ast: AST) -> StatementSemantic:
     used_variables = set()
     used_objects = set()
     used_methods = set()


### PR DESCRIPTION
Fix #638.

Add ability to launch `extract_semantic...` functions from CLI.

Help message:
```bash
python -m aibolit.extract_method_baseline.extract_semantic -h
usage: extract_semantic.py [-h] -f FILE [-c CLASS_NAME] [-m METHOD_NAME]

Extracts semantic from specified methods

optional arguments:
  -h, --help            show this help message and exit
  -f FILE, --file FILE  File path to JAVA source code for extracting semantic
  -c CLASS_NAME, --class CLASS_NAME
                        Class name of method to parse, if omitted all classes are considered
  -m METHOD_NAME, --method METHOD_NAME
                        Method name to parse, if omitted all method are considered
```

You can filter methods by their names and class names they contained in.

Output example:
```bash
python -m aibolit.extract_method_baseline.extract_semantic -f test/integration/samples/AnnotationOffsetItem.java
getAnnotationsOffset method in AnnotationOffsetItem class:
        Return statement on line 51 uses:
                Variables:
                        - annotationsOffset
getItem method in AnnotationOffsetItem class:
        Return statement on line 55 uses:
                Variables:
                        - _item
toDataType method in AnnotationOffsetItem class:
        Local variable declaration on line 60 uses:
                Objects:
                        - StructConverterUtil
                Methods:
                        - toDataType
        Statement expression on line 61 uses:
                Objects:
                        - dataType
                Methods:
                        - setCategoryPath
        Return statement on line 62 uses:
                Variables:
                        - dataType
```