### PR TITLE
Updated find_start_and_end_lines() in  __main__.py

### DIFF
--- a/aibolit/__main__.py
+++ b/aibolit/__main__.py
@@ -140,7 +140,7 @@ def __count_value(value_dict, input_params, code_lines_dict, java_file: str, is_
         val = value_dict['make']().value(ast)
         if not is_metric:
             input_params[acronym] = len(val)
-            code_lines_dict['lines_' + acronym] = val
+            code_lines_dict["lines_" + acronym] = val
         else:
             input_params[acronym] = val
     except Exception:
@@ -151,7 +151,7 @@ def __count_value(value_dict, input_params, code_lines_dict, java_file: str, is_
         )
 
 
-def flatten(l):
+def flatten(l: List[List[Any]]) -> List[Any]:
     return [item for sublist in l for item in sublist]
 
 

--- a/aibolit/__main__.py
+++ b/aibolit/__main__.py
@@ -213,16 +213,29 @@ def find_annotation_by_node_type(
     return annonations
 
 
-def find_start_and_end_lines(node) -> Tuple[int, int]:  # noqa: C901
+def find_start_and_end_lines(node: javalang.tree.Node) -> Tuple[int, int]:  # noqa: C901
+    """Find the start and end line numbers for a given AST node.
+
+    Args:
+        node: A javalang AST node to analyze
+
+    Returns:
+        A tuple containing (start_line, end_line) where:
+        - start_line is the line number where the node begins
+        - end_line is the line number where the node ends
+
+    Note:
+        This function traverses the entire AST subtree to find the maximum line number.
+    """
     max_line = node.position.line
 
-    def check_max_position(node):
+    def check_max_position(node: javalang.tree.Node) -> None:
         nonlocal max_line
         if hasattr(node, '_position'):
             if node.position.line > max_line:
                 max_line = node.position.line
 
-    def traverse(node):
+    def traverse(node: javalang.tree.Node) -> None:
         nonlocal max_line
         check_max_position(node)
 
@@ -246,7 +259,6 @@ def find_start_and_end_lines(node) -> Tuple[int, int]:  # noqa: C901
                                 traverse(infant)
                     else:
                         check_max_position(child)
-
         else:
             return
 


### PR DESCRIPTION
I've added proper type annotation for the input parameter node - such as javalang.tree.Node and type annotations to the nested helper functions:
check_max_position(node: javalang.tree.Node) -> None
traverse(node: javalang.tree.Node) -> None

Also I've added comprehensive docstring explaining:
What the function does, input and return parameters brief explanation