### PR TITLE
Resolve #697: Temporary fix: limit `xcop`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,8 @@ it:
 	./test/integration/test_recommend.sh
 
 xcop:
-	xcop $$(find . -name '*.xml')
+	xcop $$(find ./aibolit -name '*.xml')
+	xcop $$(find ./scripts -name '*.xml')
 
 flake8:
 	python3 -m flake8 aibolit test scripts setup.py --exclude scripts/target/*


### PR DESCRIPTION
This PR (resolve #697) updates the `Makefile` to run `xcop` only on the `aibolit/` and `scripts/` directories.
This helps avoid issues with virtual environments being unintentionally scanned.

**_Note: the `.xcop` ignore config does not seem to work as expected — it doesn't ignore the virtual environment directory. This needs further investigation._**