### PR TITLE
Use pytest framework instead of unittest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ install:
 	python3 aibolit --version
 
 test:
-	python3 -m pytest test/
+	python3 -m pytest --cov=aibolit/ test/
 
 it:
 	python3 -m test.integration.test_patterns_and_metrics

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ install:
 	python3 aibolit --version
 
 test:
-	python3 -m coverage run -m unittest discover
+	python3 -m pytest test/
 
 it:
 	python3 -m test.integration.test_patterns_and_metrics

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ packaging>=23.0  # For version parsing, updated for sphinx compatibility
 pandas==2.2.3
 pebble==4.5.3
 pylint==3.3.7
+pytest==8.3.5
 scikit-learn==1.6.1
 scipy==1.15.3
 setuptools==80.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ cached-property==1.2.0
 catboost==1.2.8
 chardet>=5.0.0  # Replace cchardet with chardet for Python 3.12 compatibility
 codecov==2.1.13
-coverage==5.0.3
 deprecated==1.2.10
 flake8==7.2.0
 javalang==0.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ pandas==2.2.3
 pebble==4.5.3
 pylint==3.3.7
 pytest==8.3.5
+pytest-cov==6.1.1
 scikit-learn==1.6.1
 scipy==1.15.3
 setuptools==80.7.1

--- a/test/metrics/hv/__init__.py
+++ b/test/metrics/hv/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2019-2025 Aibolit
+# SPDX-License-Identifier: MIT

--- a/test/metrics/hv/test_all_types.py
+++ b/test/metrics/hv/test_all_types.py
@@ -3,6 +3,8 @@
 
 import unittest
 
+from aibolit.metrics.hv.main import HVMetric
+
 
 class JavaTestCase(unittest.TestCase):
     @classmethod
@@ -11,8 +13,6 @@ class JavaTestCase(unittest.TestCase):
 
     def runAnalysis(self):
         super(JavaTestCase, self).setUp()
-        from aibolit.metrics.hv.main import HVMetric
-
         file = 'test/metrics/cc/Complicated.java'
         metric = HVMetric(file)
         res = metric.value()

--- a/test/metrics/npath/__init__.py
+++ b/test/metrics/npath/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2019-2025 Aibolit
+# SPDX-License-Identifier: MIT

--- a/test/metrics/npath/test_all_types.py
+++ b/test/metrics/npath/test_all_types.py
@@ -40,7 +40,9 @@ class JavaTestCase(unittest.TestCase):
             file = 'test/metrics/npath/ooo1.java'
             metric = NPathMetric(file)
             metric.value(True)
-        self.assertTrue('File test/metrics/npath/ooo1.java does not exist' == str(context.exception))
+        self.assertTrue(
+            'File test/metrics/npath/ooo1.java does not exist' == str(context.exception)
+        )
 
     def testMediumScore(self):
         super(JavaTestCase, self).setUp()


### PR DESCRIPTION
In this PR we use `pytest` instead of `unittest` framework for running automated tests.

1. Add requirements: `pytest` and `pytest-cov` (for coverage)
2. Use `pytest` in `make test` command

Closes #684 