### PR TITLE
Drop dependence on cached_property package

### DIFF
--- a/aibolit/ast_framework/ast_node.py
+++ b/aibolit/ast_framework/ast_node.py
@@ -1,10 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2025 Aibolit
 # SPDX-License-Identifier: MIT
 
+from functools import cached_property
 from typing import Any, List, Iterator, Optional
 
 from networkx import DiGraph, dfs_preorder_nodes  # type: ignore
-from cached_property import cached_property  # type: ignore
 
 from aibolit.ast_framework._auxiliary_data import (
     common_attributes,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 beautifulsoup4==4.8.2
 bs4==0.0.1
-cached-property==1.2.0
 catboost==1.2.8
 chardet>=5.0.0  # Replace cchardet with chardet for Python 3.12 compatibility
 codecov==2.1.13


### PR DESCRIPTION
In this PR we drop dependence on `cached_property` package
in favor of `functools.cached_property` decorator,
which is a part of Python standard library since Python 3.8.

Closes #703