### PR TITLE
TYP: fix typing errors in aibolit/utils

### DIFF
--- a/.github/workflows/ty.yml
+++ b/.github/workflows/ty.yml
@@ -18,8 +18,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Create venv
+        run: |
+          python3 -m venv .venv
+          source .venv/bin/activate
+
       - name: Install aibolit dependencies
-        run: pip install -r requirements.txt
+        run: python -m pip install -r requirements.txt
 
       - name: Install uv (from Astral)
         run: |

--- a/.github/workflows/ty.yml
+++ b/.github/workflows/ty.yml
@@ -18,6 +18,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Install aibolit dependencies
+        run: pip install -r requirements.txt
+
       - name: Install uv (from Astral)
         run: |
           curl -LsSf https://astral.sh/uv/install.sh | bash

--- a/aibolit/__main__.py
+++ b/aibolit/__main__.py
@@ -22,6 +22,7 @@ from sys import stdout
 from typing import List, Any, Dict, Tuple
 
 import javalang
+import javalang.tree
 from javalang.parser import JavaSyntaxError
 import numpy as np  # type: ignore
 import requests  # type: ignore[import-untyped]

--- a/aibolit/metrics/countLeaves/numberofleaves.py
+++ b/aibolit/metrics/countLeaves/numberofleaves.py
@@ -3,6 +3,7 @@
 from typing import List, Type, Any
 
 import javalang
+import javalang.tree
 
 from aibolit.utils.ast_builder import build_ast
 

--- a/aibolit/patterns/var_decl_diff/var_decl_diff.py
+++ b/aibolit/patterns/var_decl_diff/var_decl_diff.py
@@ -5,6 +5,7 @@
 from typing import List, Optional, Tuple, Dict
 
 import javalang
+import javalang.tree
 
 from aibolit.utils.java_parser import JavalangImproved, ASTNode
 

--- a/aibolit/utils/ast_builder.py
+++ b/aibolit/utils/ast_builder.py
@@ -1,12 +1,14 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2025 Aibolit
 # SPDX-License-Identifier: MIT
+import os
+
 from javalang.parse import parse
 from javalang.tree import CompilationUnit
 
 from aibolit.utils.encoding_detector import read_text_with_autodetected_encoding
 
 
-def build_ast(filename: str) -> CompilationUnit:
+def build_ast(filename: str | os.PathLike) -> CompilationUnit:
     return parse(read_text_with_autodetected_encoding(filename))
 
 

--- a/aibolit/utils/cfg_builder.py
+++ b/aibolit/utils/cfg_builder.py
@@ -1,8 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2025 Aibolit
 # SPDX-License-Identifier: MIT
 
-from typing import Tuple
-
 from networkx import DiGraph, disjoint_union  # type: ignore
 
 from aibolit.ast_framework import AST, ASTNodeType
@@ -26,7 +24,7 @@ def build_cfg(tree: AST) -> DiGraph:
     return g
 
 
-def _mk_cfg_graph(node: ASTNodeType) -> Tuple[DiGraph, int]:
+def _mk_cfg_graph(node: ASTNodeType) -> DiGraph:
     '''Takes in Javalang statement and returns corresponding CFG'''
     g = DiGraph()
     g.add_node(0)

--- a/aibolit/utils/encoding_detector.py
+++ b/aibolit/utils/encoding_detector.py
@@ -1,9 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2025 Aibolit
 # SPDX-License-Identifier: MIT
+import os
+
 from chardet import detect  # type: ignore
 
 
-def detect_encoding_of_file(filename: str):
+def detect_encoding_of_file(filename: str | os.PathLike):
     with open(filename, 'rb') as target_file:
         return detect_encoding_of_data(target_file.read())
 

--- a/aibolit/utils/encoding_detector.py
+++ b/aibolit/utils/encoding_detector.py
@@ -14,7 +14,7 @@ def detect_encoding_of_data(data: bytes):
     return detect(data)['encoding']
 
 
-def read_text_with_autodetected_encoding(filename: str):
+def read_text_with_autodetected_encoding(filename: str | os.PathLike):
     with open(filename, 'rb') as target_file:
         data = target_file.read()
 

--- a/aibolit/utils/filter.py
+++ b/aibolit/utils/filter.py
@@ -46,7 +46,7 @@ class Filters:
         # To-Fix: implement get/set detection with .body
         temp_list = []
         for path, node in method_node_list:
-            if node.name.startswith(('get', 'set')):
+            if node.name.startswith(('get', 'set')):  # type: ignore[unresolved-attribute]
                 pass
             else:
                 temp_list.append((path, node))
@@ -75,8 +75,8 @@ class Filters:
         """
 
         parameter_list = []
-        name: str = method_node.name
-        for parameter in method_node.parameters:
+        name: str = method_node.name  # type: ignore[unresolved-attribute]
+        for parameter in method_node.parameters:  # type: ignore[unresolved-attribute]
             parameter_list.append((parameter.name, parameter.type.name))
         parameter_tuple: Tuple[Tuple[str, str], ...] = tuple(parameter_list)
         return name, parameter_tuple

--- a/aibolit/utils/java_parser.py
+++ b/aibolit/utils/java_parser.py
@@ -4,6 +4,7 @@
 from typing import List, Type
 
 import javalang
+import javalang.tree
 
 from aibolit.utils.lines import Lines
 

--- a/aibolit/utils/java_parser.py
+++ b/aibolit/utils/java_parser.py
@@ -4,6 +4,7 @@
 from typing import List, Type
 
 import javalang
+import javalang.ast
 import javalang.tree
 
 from aibolit.utils.lines import Lines

--- a/aibolit/utils/lines.py
+++ b/aibolit/utils/lines.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2025 Aibolit
 # SPDX-License-Identifier: MIT
+import os
 from typing import List, Tuple
 
 from javalang.ast import Node
@@ -16,7 +17,7 @@ class Lines:
     Deprecated: This class is used ony once by JavalangImproved
                 and does not provide any complex functionality, so should be removed.
     """
-    def __init__(self, filename: str):
+    def __init__(self, filename: str | os.PathLike) -> None:
         source_code = read_text_with_autodetected_encoding(filename)
 
         self._lines = source_code.splitlines(keepends=True)

--- a/scripts/02-filter-and-move.py
+++ b/scripts/02-filter-and-move.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 import chardet
 import javalang
+import javalang.tree
 import pandas as pd
 from sklearn.model_selection import train_test_split
 

--- a/test/recommend/test_recommend_pipeline.py
+++ b/test/recommend/test_recommend_pipeline.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from unittest import TestCase, skip
 
 import javalang
+import javalang.tree
 
 from aibolit.config import Config
 


### PR DESCRIPTION
This PR fixes multiple typing errors related to `aibolit/utils` subpackage.

Before (master branch):
```
└➜ uvx ty check | tail -n 1
WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
Found 157 diagnostics
```

This PR:
```
└➜ uvx ty check | tail -n 1
WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
Found 53 diagnostics
```

No remaining issues related to `utils`.
```
└➜ uvx ty check | grep utils
WARN ty is pre-release software and not ready for production use. Expect to encounter bugs, missing features, and fatal errors.
```

When fixing typing errors I had to ignore some of them as shown in the diffs below.
I checked that `javalang.tree.MethodDeclaration` object does indeed have methods, such as `name`, `parameters`, etc.
However, due to use of metaclasses for the declaration of `MethodDeclaration` class, these attributes are not recognized by `ty`.
Thus, I had to ignore these errors.

@yegor256 please let me know whether you prefer having a comment stating why the error is ignored, or maybe a more descriptive commit message related to this change?

```
diff --git a/aibolit/utils/filter.py b/aibolit/utils/filter.py
index 29559892..5c5650e0 100644
--- a/aibolit/utils/filter.py
+++ b/aibolit/utils/filter.py
@@ -46,7 +46,7 @@ class Filters:
         # To-Fix: implement get/set detection with .body
         temp_list = []
         for path, node in method_node_list:
-            if node.name.startswith(('get', 'set')):
+            if node.name.startswith(('get', 'set')):  # type: ignore[unresolved-attribute]
                 pass
             else:
                 temp_list.append((path, node))
@@ -75,8 +75,8 @@ class Filters:
         """

         parameter_list = []
-        name: str = method_node.name
-        for parameter in method_node.parameters:
+        name: str = method_node.name  # type: ignore[unresolved-attribute]
+        for parameter in method_node.parameters:  # type: ignore[unresolved-attribute]
             parameter_list.append((parameter.name, parameter.type.name))
         parameter_tuple: Tuple[Tuple[str, str], ...] = tuple(parameter_list)
         return name, parameter_tuple
```

Closes #713 