### PR TITLE
FIX: unexpected indents in docstrings

### DIFF
--- a/aibolit/metrics/external_methods_called/external_methods_called.py
+++ b/aibolit/metrics/external_methods_called/external_methods_called.py
@@ -5,12 +5,13 @@ import os
 
 class ExternalMethodsCalled:
     """
-        Measure the number of external methods called by the class.
-        @todo #183:30min Implement external method called metric
-         In the methods in the class an external method for this class can
-         be called. So number of external methods called by all the methods
-         in the class is suggested as a metric. Implement this metric and then
-         enable tests in test_external_methods_called.py
+    Measure the number of external methods called by the class.
+
+    @todo #183:30min Implement external method called metric
+    In the methods in the class an external method for this class can
+    be called. So number of external methods called by all the methods
+    in the class is suggested as a metric. Implement this metric and then
+    enable tests in test_external_methods_called.py
     """
 
     def __init__(self):

--- a/aibolit/metrics/local_methods_calls/local_methods_calls.py
+++ b/aibolit/metrics/local_methods_calls/local_methods_calls.py
@@ -5,12 +5,13 @@ import os
 
 class LocalMethodsCalls:
     """
-        Measure the number of local methods called by the class.
-        @todo #183:30min Implement local method called metric
-         In the methods in the class an local method (method that is defined in this class)
-         can be called. So number of local methods calls by all the methods in the
-         class is suggested as a metric. Implement this metric and then
-         enable tests in test_local_methods_calls.py
+    Measure the number of local methods called by the class.
+
+    @todo #183:30min Implement local method called metric
+    In the methods in the class an local method (method that is defined in this class)
+    can be called. So number of local methods calls by all the methods in the
+    class is suggested as a metric. Implement this metric and then
+    enable tests in test_local_methods_calls.py
     """
 
     def __init__(self):

--- a/aibolit/metrics/ncss/ncss.py
+++ b/aibolit/metrics/ncss/ncss.py
@@ -7,10 +7,11 @@ from aibolit.ast_framework import AST, ASTNode, ASTNodeType
 class NCSSMetric:
     """
     NCSS metric counts non-commenting source statements.
+
     It counts:
-     - keywords from _keyword_node_types
-     - declarations from _declarations_node_types
-     - local variable declarations and statement expressions
+    - keywords from _keyword_node_types
+    - declarations from _declarations_node_types
+    - local variable declarations and statement expressions
     """
 
     def value(self, ast: AST) -> int:

--- a/aibolit/patterns/bidirect_index/bidirect_index.py
+++ b/aibolit/patterns/bidirect_index/bidirect_index.py
@@ -11,13 +11,15 @@ class BidirectIndex:
     def value(self, filename: str | os.PathLike):
         """
         Finds if a variable is being incremented and decremented within the same method
+
         :param filename: filename to be analyzed
         :return: list of LineNumber with the variable declaration lines
+
         @todo #139:30min Implement bidirect index pattern
-         If the same numeric variable is incremented and decremented within the same method,
-         it's a pattern. A numeric variable should either be always growing or decreasing.
-         Bi-directional index is confusing. The method must return a list with the line numbers
-         of the variables that match this pattern. After implementation, activate tests in
-         test_bidirect_index.py
+        If the same numeric variable is incremented and decremented within the same method,
+        it's a pattern. A numeric variable should either be always growing or decreasing.
+        Bi-directional index is confusing. The method must return a list with the line numbers
+        of the variables that match this pattern. After implementation, activate tests in
+        test_bidirect_index.py
         """
         return []

--- a/aibolit/patterns/mutable_index/mutable_index.py
+++ b/aibolit/patterns/mutable_index/mutable_index.py
@@ -11,11 +11,13 @@ class MutableIndex:
     def value(self, filename: str | os.PathLike):
         """
         Traverse over AST tree and finds loops with mutable index
+
         :return:
         List of line number of loops with mutable index
+
         @todo #147:30min Implement MutableIndex pattern
-         We need to implement the code on mutable index pattern. It must return the number
-         of the lines where we have an index of a for loop being mutated. After implementing,
-         the method, enable all tests in test_mutable_index.py
+        We need to implement the code on mutable index pattern. It must return the number
+        of the lines where we have an index of a for loop being mutated. After implementing,
+        the method, enable all tests in test_mutable_index.py
         """
         return []

--- a/aibolit/patterns/mutable_index/mutable_index.py
+++ b/aibolit/patterns/mutable_index/mutable_index.py
@@ -12,8 +12,7 @@ class MutableIndex:
         """
         Traverse over AST tree and finds loops with mutable index
 
-        :return:
-        List of line number of loops with mutable index
+        :return: List of line number of loops with mutable index
 
         @todo #147:30min Implement MutableIndex pattern
         We need to implement the code on mutable index pattern. It must return the number

--- a/aibolit/patterns/non_final_argument/non_final_argument.py
+++ b/aibolit/patterns/non_final_argument/non_final_argument.py
@@ -13,11 +13,13 @@ class NonFinalArgument:
     def value(self, filename: str | os.PathLike) -> List[LineNumber]:
         """
         Returns the line numbers of the file name which contains no final arguments
+
         :param filename: name of the file
         :return: number of the lines with non-final arguments
+
         @todo #146:30min Implement NonFinalArgument pattern.
-         All method arguments must have final modifiers. Once we find an argument
-         without final, it's a pattern. After implementing that, enable tests in
-         test_non_final_argument.py
+        All method arguments must have final modifiers. Once we find an argument
+        without final, it's a pattern. After implementing that, enable tests in
+        test_non_final_argument.py
         """
         return []

--- a/aibolit/utils/cfg_builder.py
+++ b/aibolit/utils/cfg_builder.py
@@ -33,7 +33,8 @@ def _mk_cfg_graph(node: ASTNodeType) -> DiGraph:
 
 def _compose_two_graphs(g1: DiGraph, g2: DiGraph) -> DiGraph:
     """Compose two graphs by creating edge between last of fist graph & fist of second.
-       We assume that node in the each graph G has order from 0 to len(G)-1
+
+    We assume that node in the each graph G has order from 0 to len(G)-1
     """
     g = disjoint_union(g1, g2)
     g.add_edge(len(g1) - 1, len(g1))

--- a/aibolit/utils/java_parser.py
+++ b/aibolit/utils/java_parser.py
@@ -45,9 +45,10 @@ class ASTNode:
 
 class JavalangImproved:
     """
-    Thi class flattens AST to provie easier interface.
+    This class flattens AST to provie easier interface.
+
     Deprecated: flatening the AST leads to lose of information and bugs.
-                All patterns using it should start traversing the tree manually.
+    All patterns using it should start traversing the tree manually.
     """
 
     def __init__(self, filename: str):

--- a/aibolit/utils/lines.py
+++ b/aibolit/utils/lines.py
@@ -14,8 +14,9 @@ from aibolit.utils.encoding_detector import read_text_with_autodetected_encoding
 class Lines:
     """
     Return the lines for some AST
+
     Deprecated: This class is used ony once by JavalangImproved
-                and does not provide any complex functionality, so should be removed.
+    and does not provide any complex functionality, so should be removed.
     """
     def __init__(self, filename: str | os.PathLike) -> None:
         source_code = read_text_with_autodetected_encoding(filename)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ build-backend = "setuptools.build_meta"
 mypy_path = "stubs"
 
 [tool.ruff.lint]
-select = [
+extend-select = [
   "D207",
   "D208",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,3 +45,9 @@ build-backend = "setuptools.build_meta"
 
 [tool.mypy]
 mypy_path = "stubs"
+
+[tool.ruff.lint]
+select = [
+  "D207",
+  "D208",
+]


### PR DESCRIPTION
This PR fixes unexpected indentations in docstrings,
which used to trigger errors when building docs.

Closes #719