### PR TITLE
FIX: handle non-OK status code when requesting aibolit version

### DIFF
--- a/aibolit/__main__.py
+++ b/aibolit/__main__.py
@@ -887,7 +887,9 @@ def run_thread(files, args):
 
 def get_versions(pkg_name):
     url = f'https://pypi.python.org/pypi/{pkg_name}/json'
-    releases = json.loads(requests.get(url, timeout=15).content)['releases']
+    response = requests.get(url, timeout=15)
+    response.raise_for_status()
+    releases = json.loads(response.content)['releases']
     return sorted(releases, key=parse_version, reverse=True)
 
 
@@ -896,9 +898,13 @@ def main():
         max_available_version = get_versions('aibolit')[0]
         if max_available_version != __version__:
             print(f'Version {max_available_version} is available, but you are using {__version__}')
-    except (requests.exceptions.ConnectionError, requests.exceptions.Timeout,
-            requests.exceptions.ReadTimeout):
-        print('Can\'t check aibolit version. Network is not available')
+    except (
+            requests.exceptions.HTTPError,
+            requests.exceptions.ConnectionError,
+            requests.exceptions.Timeout,
+            requests.exceptions.ReadTimeout,
+    ):
+        print('Can\'t check aibolit version. Network is not available or PyPI does not respond')
     try:
         commands = {
             'train': train,


### PR DESCRIPTION
This change handles non-OK status code when requesting the latest aibolit version from PyPI.

`response.raise_for_status()` succeeds if status code is less than 400, otherwise raises `HTTPError`, which we then handle on the caller's side https://docs.python-requests.org/en/latest/_modules/requests/models/#Response.raise_for_status

Closes #722