### PR TITLE
Add a missing test case for SendNull

### DIFF
--- a/aibolit/patterns/send_null/send_null.py
+++ b/aibolit/patterns/send_null/send_null.py
@@ -13,11 +13,7 @@ class SendNull:
     def __is_null(self, val: Any) -> bool:
         if not hasattr(val, 'value'):
             return False
-        if not isinstance(val.value, str):
-            return False
-        if val.value != 'null':
-            return False
-        return True
+        return val.value == 'null'
 
     def value(self, ast: AST) -> List[int]:
 

--- a/aibolit/patterns/send_null/send_null.py
+++ b/aibolit/patterns/send_null/send_null.py
@@ -13,7 +13,11 @@ class SendNull:
     def __is_null(self, val: Any) -> bool:
         if not hasattr(val, 'value'):
             return False
-        return val.value == 'null'
+        if not isinstance(val.value, str):
+            return False
+        if val.value != 'null':
+            return False
+        return True
 
     def value(self, ast: AST) -> List[int]:
 

--- a/test/patterns/send_null/test_send_null.py
+++ b/test/patterns/send_null/test_send_null.py
@@ -281,6 +281,21 @@ def test_pass_null_as_the_second_parameter_into_another_ctor() -> None:
     assert _offending_lines(content) == [3]
 
 
+def test_null_in_ternary_expression_comparison_with_class_creator() -> None:
+    content = dedent(
+        """\
+        public class Dummy {
+            transient volatile Set<Integer> keySet = null;
+            public Set<Integer> keySet() {
+                Set<Integer> ks = keySet;
+                return (ks != null ? ks : (keySet = new KeySet()));
+            }
+        }
+        """
+    ).strip()
+    assert _offending_lines(content) == []
+
+
 def _offending_lines(content: str) -> list[int]:
     """Return a list of lines offending SendNull pattern."""
     ast = AST.build_from_javalang(build_ast_from_string(content))


### PR DESCRIPTION
This PR adds a missing test case to cover a line in `SendNull`.
The test case is taken from [test/integration/samples/IntKeyMap.java](https://github.com/cqfn/aibolit/blob/master/test/integration/samples/IntKeyMap.java#L705).

Originally I implemented a refactoring of `SendNull.value`, so that we compare `val.value == 'null'`, however it fails if `val.value` is `ASTNode`, which does not have `__eq__` defined for comparison with strings.
Thus, I reverted the refactoring and only added the test case.

Closes #709