### PR TITLE
Fix bs4-related deprecation warning

### DIFF
--- a/aibolit/metrics/npath/main.py
+++ b/aibolit/metrics/npath/main.py
@@ -56,7 +56,7 @@ class NPathMetric():
         content = []
         with open(f'{root}/target/pmd.xml', 'r', encoding='utf-8') as file:
             content = file.read()
-            soup = BeautifulSoup(content, 'lxml')
+            soup = BeautifulSoup(content, features='xml')
             files = soup.find_all('file')
             for file in files:
                 out = file.violation.string

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-beautifulsoup4==4.8.2
+beautifulsoup4==4.13.4
 bs4==0.0.1
 catboost==1.2.8
 chardet>=5.0.0  # Replace cchardet with chardet for Python 3.12 compatibility


### PR DESCRIPTION
This PR suggests using the newest version of `beautifulsoup4==4.13.4`.

They removed the deprecated parameter `strip_cdata` starting from version 4.13.0.

Changelog: https://git.launchpad.net/beautifulsoup/tree/CHANGELOG

Closes #730