### PR TITLE
Avoid flattening a 1D numpy array

### DIFF
--- a/aibolit/model/model.py
+++ b/aibolit/model/model.py
@@ -121,7 +121,7 @@ class PatternRankingModel(BaseEstimator):
         )
 
         self.model = model
-        self.model.fit(X, y.ravel(), logging_level='Silent')
+        self.model.fit(X, y, logging_level='Silent')
 
     def sigmoid(self, x):
         return 1 / (1 + np.exp(-x))


### PR DESCRIPTION
This PR avoid flattening a 1D numpy array with `ravel` method, which emits a warning for 1D arrays.

Closes #732