### PR TITLE
Add a failing test on ClassicGetter

### DIFF
--- a/test/patterns/classic_getter/test_classic_getter.py
+++ b/test/patterns/classic_getter/test_classic_getter.py
@@ -2,11 +2,14 @@
 # SPDX-License-Identifier: MIT
 
 from pathlib import Path
+from textwrap import dedent
 from unittest import TestCase
+
+import pytest
 
 from aibolit.patterns.classic_getter.classic_getter import ClassicGetter
 from aibolit.ast_framework import AST
-from aibolit.utils.ast_builder import build_ast
+from aibolit.utils.ast_builder import build_ast, build_ast_from_string
 
 
 class SetterTestCase(TestCase):
@@ -39,3 +42,25 @@ class SetterTestCase(TestCase):
         pattern = ClassicGetter()
         lines = pattern.value(ast)
         self.assertEqual(lines, [8])
+
+
+@pytest.mark.xfail(reason='ClassicGetter implementation is incorrect')
+def test_getter_using_this_reference() -> None:
+    content = dedent(
+        """\
+        class Dummy {
+            private int value;
+            public int getValue() {
+                return this.value;
+            }
+        }
+        """
+    ).strip()
+    assert _offending_lines(content) == [3]
+
+
+def _offending_lines(content: str) -> list[int]:
+    """Return a list of lines offending ClassicGetter pattern."""
+    ast = AST.build_from_javalang(build_ast_from_string(content))
+    pattern = ClassicGetter()
+    return pattern.value(ast)

--- a/test/patterns/classic_getter/test_classic_getter.py
+++ b/test/patterns/classic_getter/test_classic_getter.py
@@ -44,7 +44,7 @@ class SetterTestCase(TestCase):
         self.assertEqual(lines, [8])
 
 
-@pytest.mark.xfail(reason='ClassicGetter implementation is incorrect')
+@pytest.mark.xfail(reason='ClassicGetter implementation is incorrect #736')
 def test_getter_using_this_reference() -> None:
     content = dedent(
         """\

--- a/test/patterns/classic_getter/test_classic_getter.py
+++ b/test/patterns/classic_getter/test_classic_getter.py
@@ -46,6 +46,9 @@ class SetterTestCase(TestCase):
 
 @pytest.mark.xfail(reason='ClassicGetter implementation is incorrect #736')
 def test_getter_using_this_reference() -> None:
+    # TODO #736:30min/DEV Fix ClassicGetter pattern implementation,
+    #  so that it gets triggered when the getter's body references `this`.
+    #  When completed, remove `xfail` mark.
     content = dedent(
         """\
         class Dummy {


### PR DESCRIPTION
This PR adds a failing test on classic getter pattern where `this` reference is used.

Xref: #736