### PR TITLE
Drop texlive-fonts-recommended from latexmk workflow

### DIFF
--- a/.github/workflows/latexmk.yml
+++ b/.github/workflows/latexmk.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: 'true'
-      - run: sudo apt-get update && sudo apt-get install --yes ghostscript
       - uses: yegor256/latexmk-action@0.16.2
         with:
           path: wp

--- a/.github/workflows/latexmk.yml
+++ b/.github/workflows/latexmk.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: 'true'
-      - run: sudo apt-get update && sudo apt-get install --yes ghostscript texlive-fonts-recommended
+      - run: sudo apt-get update && sudo apt-get install --yes ghostscript
       - uses: yegor256/latexmk-action@0.16.2
         with:
           path: wp


### PR DESCRIPTION
Drop installation of `texlive-fonts-recommended` from `latexmk` workflow
as we expect that the newer docker image `yegor256/latex` already contains the required fonts.

Closes #724 
Xref: https://github.com/yegor256/dockers/issues/30