### PR TITLE
Add test case to fully cover `ClassicGetter`

### DIFF
--- a/aibolit/patterns/classic_getter/classic_getter.py
+++ b/aibolit/patterns/classic_getter/classic_getter.py
@@ -21,9 +21,6 @@ class ClassicGetter:
                 return False
 
             if not _is_return(node):
-                # TODO #758:15min/DEV Add test to cover all conditions of this if statement.
-                #  One more case is required with getSomething method,
-                #  that does not even return anything.
                 return False
 
             return_this_attr = (

--- a/test/patterns/classic_getter/test_classic_getter.py
+++ b/test/patterns/classic_getter/test_classic_getter.py
@@ -56,6 +56,19 @@ def test_getter_using_this_reference() -> None:
     assert _offending_lines(content) == [3]
 
 
+def test_getSomething_method_that_does_not_return() -> None:
+    content = dedent(
+        """\
+        class Dummy {
+            public void getProudOfThisCode() {
+                System.out.println('This code does not have getters');
+            }
+        }
+        """
+    ).strip()
+    assert not _offending_lines(content)
+
+
 def _offending_lines(content: str) -> list[int]:
     """Return a list of lines offending ClassicGetter pattern."""
     ast = AST.build_from_javalang(build_ast_from_string(content))


### PR DESCRIPTION
In this PR we add a case where `getSomething` method
does not return anything.
This is the only remaining case to fully cover `ClassicGetter` pattern.

Closes #762 