### PR TITLE
Drop irrelevant puzzle in `DockerProxy.java`

### DIFF
--- a/test/integration/check/java/com/artipie/docker/DockerProxy.java
+++ b/test/integration/check/java/com/artipie/docker/DockerProxy.java
@@ -26,10 +26,6 @@ import org.reactivestreams.Publisher;
  * Docker proxy slice created from config.
  *
  * @since 0.9
- * @todo #313:30min Unit test coverage for `DockerProxy` class
- *  `DockerProxy` class lacks unit test coverage. It should be tested that slice is built properly
- *  from configuration (e.g. handles simple response like 'GET /v2/') and fails any request for bad
- *  configuration (some required settings are missing).
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 public final class DockerProxy implements Slice {


### PR DESCRIPTION
This PR drop an irrelevant puzzle in `DockerProxy.java`. Apparently the file `DockerProxy.java` was taken from another project for a purpose of an integration testing fixture.
However, `0pdd` bot treated the puzzle in the body of the file as a real one.

Closes #754