### PR TITLE
Drop irrelevant puzzles in `YamlSettings.java`

### DIFF
--- a/test/integration/check/java/com/artipie/YamlSettings.java
+++ b/test/integration/check/java/com/artipie/YamlSettings.java
@@ -138,8 +138,6 @@ public final class YamlSettings implements Settings {
      * Create async yaml config from content publisher.
      * @param pub Flow publisher
      * @return Completion stage of yaml
-     * @todo #146:30min Extract this method to a class: we have the same method in RepoConfig. After
-     *  extracting use this new class here and in RepoConfig. Do not forget about test.
      */
     private static CompletionStage<YamlMapping> yamlFromPublisher(
         final Publisher<ByteBuffer> pub

--- a/test/integration/check/java/com/artipie/YamlSettings.java
+++ b/test/integration/check/java/com/artipie/YamlSettings.java
@@ -29,12 +29,6 @@ import org.reactivestreams.Publisher;
  * Settings built from YAML.
  *
  * @since 0.1
- * @todo #285:30min Settings configuration for GitHub auth.
- *  Add additional settings configuration for GitHub authentication,
- *  now it's applied by default to auth from yaml using chained authentication, see auth()
- *  method. We can configure this chain via settings and compose complex authentication
- *  providers there. E.g. user can use ordered list of env auth, github auth
- *  and auth from yaml file.
  * @checkstyle ReturnCountCheck (500 lines)
  */
 public final class YamlSettings implements Settings {


### PR DESCRIPTION
This PR drop an irrelevant puzzles in `YamlSettings.java`.
Apparently the file was taken from another project for a purpose of an integration testing fixture.
However, `0pdd` bot treated the puzzle in the body of the file as a real one.

Closes #750, #751