### PR TITLE
Implement pattern `NonFinalArgument`

### DIFF
--- a/aibolit/patterns/non_final_argument/non_final_argument.py
+++ b/aibolit/patterns/non_final_argument/non_final_argument.py
@@ -1,9 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2025 Aibolit
 # SPDX-License-Identifier: MIT
 import os
-from typing import List
+from typing import Iterator
 
-from aibolit.ast_framework import AST, ASTNodeType
+from aibolit.ast_framework import AST, ASTNode, ASTNodeType
 from aibolit.types_decl import LineNumber
 from aibolit.utils.ast_builder import build_ast
 
@@ -12,20 +12,24 @@ class NonFinalArgument:
     def __init__(self):
         pass
 
-    def value(self, filename: str | os.PathLike) -> List[LineNumber]:
+    def value(self, filename: str | os.PathLike) -> list[LineNumber]:
         """
         Returns the line numbers of the file name which contains no final arguments
 
         :param filename: name of the file
         :return: number of the lines with non-final arguments
         """
-        ast = AST.build_from_javalang(build_ast(filename))
-        lines: list[int] = []
-        for node in ast.get_proxy_nodes(
-            ASTNodeType.METHOD_DECLARATION,
-            ASTNodeType.CONSTRUCTOR_DECLARATION,
-        ):
-            for parameter in node.parameters:
-                if 'final' not in parameter.modifiers:
-                    lines.append(node.line)
-        return sorted(lines)
+        return sorted(
+            node.line
+            for node in _offending_nodes(AST.build_from_javalang(build_ast(filename)))
+        )
+
+
+def _offending_nodes(ast: AST) -> Iterator[ASTNode]:
+    for node in ast.get_proxy_nodes(
+        ASTNodeType.METHOD_DECLARATION,
+        ASTNodeType.CONSTRUCTOR_DECLARATION,
+    ):
+        for parameter in node.parameters:
+            if 'final' not in parameter.modifiers:
+                yield node

--- a/aibolit/patterns/non_final_argument/non_final_argument.py
+++ b/aibolit/patterns/non_final_argument/non_final_argument.py
@@ -3,7 +3,7 @@
 import os
 from typing import Iterator
 
-from aibolit.ast_framework import AST, ASTNode, ASTNodeType
+from aibolit.ast_framework import AST, ASTNodeType
 from aibolit.types_decl import LineNumber
 from aibolit.utils.ast_builder import build_ast
 
@@ -19,17 +19,14 @@ class NonFinalArgument:
         :param filename: name of the file
         :return: number of the lines with non-final arguments
         """
-        return sorted(
-            node.line
-            for node in _offending_nodes(AST.build_from_javalang(build_ast(filename)))
-        )
+        return sorted(_offending_lines(AST.build_from_javalang(build_ast(filename))))
 
 
-def _offending_nodes(ast: AST) -> Iterator[ASTNode]:
+def _offending_lines(ast: AST) -> Iterator[LineNumber]:
     for node in ast.get_proxy_nodes(
         ASTNodeType.METHOD_DECLARATION,
         ASTNodeType.CONSTRUCTOR_DECLARATION,
     ):
         for parameter in node.parameters:
             if 'final' not in parameter.modifiers:
-                yield node
+                yield node.line

--- a/aibolit/patterns/non_final_argument/non_final_argument.py
+++ b/aibolit/patterns/non_final_argument/non_final_argument.py
@@ -3,7 +3,9 @@
 import os
 from typing import List
 
+from aibolit.ast_framework import AST, ASTNodeType
 from aibolit.types_decl import LineNumber
+from aibolit.utils.ast_builder import build_ast
 
 
 class NonFinalArgument:
@@ -17,8 +19,13 @@ class NonFinalArgument:
         :param filename: name of the file
         :return: number of the lines with non-final arguments
         """
-        # @todo #146:30min Implement NonFinalArgument pattern.
-        #  All method arguments must have final modifiers. Once we find an argument
-        #  without final, it's a pattern. After implementing that, enable tests in
-        #  test_non_final_argument.py
-        return []
+        ast = AST.build_from_javalang(build_ast(filename))
+        lines: list[int] = []
+        for node in ast.get_proxy_nodes(
+            ASTNodeType.METHOD_DECLARATION,
+            ASTNodeType.CONSTRUCTOR_DECLARATION,
+        ):
+            for parameter in node.parameters:
+                if 'final' not in parameter.modifiers:
+                    lines.append(node.line)
+        return sorted(lines)

--- a/test/patterns/non_final_argument/test_non_final_argument.py
+++ b/test/patterns/non_final_argument/test_non_final_argument.py
@@ -2,14 +2,12 @@
 # SPDX-License-Identifier: MIT
 
 import os
-import unittest
 from pathlib import Path
 from unittest import TestCase
 
 from aibolit.patterns.non_final_argument.non_final_argument import NonFinalArgument
 
 
-@unittest.skip("Not implemented")
 class NonFinalArgumentTestCase(TestCase):
     dir_path = Path(os.path.realpath(__file__)).parent
 


### PR DESCRIPTION
This PR implements `NonFinalArgument` pattern.

I noticed that at the moment of writing the issue is already closed by PDD, but this apparently happened due to my recent PR on formatting docstrings to avoid over-indentation #721.

Closes #485