### PR TITLE
Drop puzzle from `MetricsLogPublisher.java` file

### DIFF
--- a/test/integration/check/java/com/artipie/metrics/memory/MetricsLogPublisher.java
+++ b/test/integration/check/java/com/artipie/metrics/memory/MetricsLogPublisher.java
@@ -16,10 +16,6 @@ import org.slf4j.Logger;
  * Periodic publisher of {@link InMemoryMetrics} to log.
  *
  * @since 0.9
- * @todo #231:30min Support gauge publishing in `MetricsLogPublisher`.
- *  `InMemoryMetrics` contain gauges along counters.
- *  Gauges should be published the same way as counters.
- *  Should be done after https://github.com/artipie/artipie/issues/267
  * @todo #231:30min Add tests for `MetricsLogPublisher`.
  *  It should be tested that the publisher runs periodically, collects fresh metrics data
  *  and logs the data as expected.


### PR DESCRIPTION
This PR drops puzzle from `MetricsLogPublisher.java` file, which is irrelevant as posted in an integration test fixture.

Closes #756 