### PR TITLE
Drop puzzle from `CachedAuth.java`

### DIFF
--- a/test/integration/check/java/com/artipie/auth/CachedAuth.java
+++ b/test/integration/check/java/com/artipie/auth/CachedAuth.java
@@ -19,11 +19,6 @@ import org.jruby.util.collections.ConcurrentWeakHashMap;
  * instead of calling origin authentication.
  * </p>
  * @since 0.10
- * @todo #285:30min Specify expiration time configuration.
- *  Instead of using scheduled executor to clean-up all cache map, use
- *  some configuration to clean-up only expired items, e.g. if token was not accessed for
- *  X minutes, then remove only this token. Consider using Guava's time-evicted-cache
- *  implementation: https://github.com/google/guava/wiki/CachesExplained#eviction
  */
 public final class CachedAuth implements Authentication {
 


### PR DESCRIPTION
This PR drops a puzzle from `CachedAuth.java`.
The puzzle apparently belonged to another project, but was treated as a blocker for https://github.com/cqfn/aibolit/issues/285 
This java file is an integration test fixture,
therefore the puzzle must be removed to cleanup the present project's backlog.

Closes #753