### PR TITLE
Fix expected pattern matching lines in `BidirectIndexTestCase`

### DIFF
--- a/test/patterns/bidirect_index/test_bidirect_index.py
+++ b/test/patterns/bidirect_index/test_bidirect_index.py
@@ -15,14 +15,14 @@ class BidirectIndexTestCase(TestCase):
     def test_bidirect_index_increase_decrease(self):
         self.assertEqual(
             BidirectIndex().value(Path(self.dir_path, "BidirectIndexIncreaseDecrease.java")),
-            [3],
+            [6],
             "Could not find bidirect index when index increased and then decreased",
         )
 
     def test_bidirect_index_decrease_increase(self):
         self.assertEqual(
             BidirectIndex().value(Path(self.dir_path, "BidirectIndexDecreaseIncrease.java")),
-            [3],
+            [6],
             "Could not find bidirect index when index decreased and then increased",
         )
 
@@ -31,7 +31,7 @@ class BidirectIndexTestCase(TestCase):
             BidirectIndex().value(
                 Path(self.dir_path, "BidirectIndexIncreaseDecreaseAssignment.java")
             ),
-            [3],
+            [6],
             "Could not find bidirect index when index increased and then decreased with assignment",
         )
 
@@ -40,7 +40,7 @@ class BidirectIndexTestCase(TestCase):
             BidirectIndex().value(
                 Path(self.dir_path, "BidirectIndexIncreaseAssignmentDecrease.java")
             ),
-            [3],
+            [6],
             "Could not find bidirect index when index increased with assignment and then decreased",
         )
 
@@ -49,7 +49,7 @@ class BidirectIndexTestCase(TestCase):
             BidirectIndex().value(
                 Path(self.dir_path, "BidirectIndexIncreaseAssignmentDecreaseAssignment.java")
             ),
-            [3],
+            [6],
             "Could not find bidirect index when index increased with assignment "
             "and then decreased with assignment",
         )
@@ -64,6 +64,6 @@ class BidirectIndexTestCase(TestCase):
     def test_bidirect_index_outsider(self):
         self.assertEqual(
             BidirectIndex().value(Path(self.dir_path, "BidirectIndexOutsider.java")),
-            [10],
+            [13],
             "Could not find bidirec index when index is ot of loop",
         )

--- a/test/patterns/bidirect_index/test_bidirect_index.py
+++ b/test/patterns/bidirect_index/test_bidirect_index.py
@@ -55,6 +55,9 @@ class BidirectIndexTestCase(TestCase):
         )
 
     def test_bidirect_index_hidden_scope_true(self):
+        # TODO #772:15min/DEV It is necessary to re-evaluate the correctness of this test case.
+        #  Since the scope in while and for loop changes, then presumably this is not a pattern.
+        #  Therefore, looks like the proper expected value is an empty list.
         self.assertEqual(
             BidirectIndex().value(Path(self.dir_path, "BidirectIndexHiddenScope.java")),
             [0],


### PR DESCRIPTION
This PR fixes expected offending lines in tests, matching the pattern `BidirectIndex`,
by shifting them by 3, which account for the copyright statement and a newline.

One puzzle has been added, since I suppose there was an error in the original test.

Closes #772