### PR TITLE
Drop puzzle from `MetricsLogPublisher.java`

### DIFF
--- a/test/integration/check/java/com/artipie/metrics/memory/MetricsLogPublisher.java
+++ b/test/integration/check/java/com/artipie/metrics/memory/MetricsLogPublisher.java
@@ -16,9 +16,6 @@ import org.slf4j.Logger;
  * Periodic publisher of {@link InMemoryMetrics} to log.
  *
  * @since 0.9
- * @todo #231:30min Add tests for `MetricsLogPublisher`.
- *  It should be tested that the publisher runs periodically, collects fresh metrics data
- *  and logs the data as expected.
  */
 public class MetricsLogPublisher {
 


### PR DESCRIPTION
This PR drop puzzle from `MetricsLogPublisher.java`. The puzzle is written in an integration test fixture and is not related to the present code base.

Closes #757