### PR TITLE
Qualify test case on `BidirectIndex` as non-pattern

### DIFF
--- a/test/patterns/bidirect_index/test_bidirect_index.py
+++ b/test/patterns/bidirect_index/test_bidirect_index.py
@@ -55,12 +55,9 @@ class BidirectIndexTestCase(TestCase):
         )
 
     def test_bidirect_index_hidden_scope_true(self):
-        # TODO #772:15min/DEV It is necessary to re-evaluate the correctness of this test case.
-        #  Since the scope in while and for loop changes, then presumably this is not a pattern.
-        #  Therefore, looks like the proper expected value is an empty list.
         self.assertEqual(
             BidirectIndex().value(Path(self.dir_path, "BidirectIndexHiddenScope.java")),
-            [0],
+            [],
             "Could not find bidirec index when scope is hidden",
         )
 


### PR DESCRIPTION
In this PR we qualify the test case
`test_bidirect_index_hidden_scope_true` as a non-pattern matching.

Closes #776