### PR TITLE
Drop puzzle from `InMemoryMetrics.java` intgr test fixture

### DIFF
--- a/test/integration/check/java/com/artipie/metrics/memory/InMemoryMetrics.java
+++ b/test/integration/check/java/com/artipie/metrics/memory/InMemoryMetrics.java
@@ -15,10 +15,6 @@ import java.util.concurrent.ConcurrentMap;
  * {@link Metrics} implementation storing data in memory.
  *
  * @since 0.9
- * @todo #231:30min Support gauges in InMemoryMetrics.
- *  `InMemoryMetrics.gauge()` method implementation should get or create an `InMemoryGauge` by name
- *  and store it. `InMemoryMetrics.gauges()` method should be added
- *  to create snapshot of existing gauges. Implementations are expected to be similar to counters.
  */
 public final class InMemoryMetrics implements Metrics {
 


### PR DESCRIPTION
Drop puzzle from `InMemoryMetrics.java` integration test fixture. The puzzle belongs to a separate project where this file was taken from and thus must be removed to clear the backlog.

Closes #755