### PR TITLE
Drop irrelevant puzzle from `VertxMain.java`

### DIFF
--- a/test/integration/check/java/com/artipie/VertxMain.java
+++ b/test/integration/check/java/com/artipie/VertxMain.java
@@ -116,8 +116,6 @@ public final class VertxMain implements Runnable {
      * @param path Settings path
      * @return Settings instance
      * @throws IOException On read error
-     * @todo #284:30min Extract this method to separate class and write proper unit tests
-     *  for that. Also add tests for `JavaResource` class which is used to copy resources.
      */
     private static Settings settings(final Path path) throws IOException {
         if (!Files.exists(path)) {


### PR DESCRIPTION
This PR drop an irrelevant puzzle from `VertxMain.java`. The puzzle belongs to another project, where this java file was taken from as a part of an integration test fixture.

Closes #749