### PR TITLE
Add `MvnFreeNPathMetric` for `if` statements

### DIFF
--- a/aibolit/metrics/npath/main.py
+++ b/aibolit/metrics/npath/main.py
@@ -9,6 +9,8 @@ import uuid
 
 from bs4 import BeautifulSoup
 
+from aibolit.ast_framework import AST
+
 
 class NPathMetric():
     """Main NPath Complexity class."""
@@ -77,3 +79,11 @@ class NPathMetric():
                 name = name[pos1:]
                 raise Exception(error['msg'])
         return result
+
+
+class MvnFreeNPathMetric:
+    def __init__(self, ast: AST) -> None:
+        self.ast = ast
+
+    def value(self) -> int:
+        return 0

--- a/aibolit/metrics/npath/main.py
+++ b/aibolit/metrics/npath/main.py
@@ -83,6 +83,9 @@ class NPathMetric():
 
 
 class MvnFreeNPathMetric:
+    """
+    NPathMetric class, which computes NPathMetric without use of `mvn` process.
+    """
     def __init__(self, ast: AST) -> None:
         self.ast = ast
 

--- a/aibolit/metrics/npath/main.py
+++ b/aibolit/metrics/npath/main.py
@@ -6,10 +6,11 @@ import shutil
 import subprocess
 import tempfile
 import uuid
+from typing import Iterator
 
 from bs4 import BeautifulSoup
 
-from aibolit.ast_framework import AST
+from aibolit.ast_framework import AST, ASTNodeType
 
 
 class NPathMetric():
@@ -86,4 +87,8 @@ class MvnFreeNPathMetric:
         self.ast = ast
 
     def value(self) -> int:
-        return 0
+        return sum(self._paths())
+
+    def _paths(self) -> Iterator[int]:
+        for node in self.ast.get_proxy_nodes(ASTNodeType.IF_STATEMENT):
+            yield 2

--- a/test/metrics/npath/test_all_types.py
+++ b/test/metrics/npath/test_all_types.py
@@ -80,6 +80,40 @@ class TestMvnFreeNPathMetric:
         ).strip()
         assert self._value(content) == 2
 
+    def test_one_if_else_statement(self) -> None:
+        content = dedent(
+            """\
+            class WithOneIf {
+                public void print(bool flag) {
+                    if (flag) {
+                        System.out.println("OK");
+                    } else {
+                        System.out.println("Not OK");
+                    }
+                }
+            }
+            """
+        ).strip()
+        assert self._value(content) == 2
+
+    def test_if_with_inner_if_else(self) -> None:
+        content = dedent(
+            """\
+            class WithOneIf {
+                public void print(bool flag, bool ok) {
+                    if (flag) {
+                        if (ok) {
+                            System.out.println("OK");
+                        } else {
+                            System.out.println("Not OK");
+                        }
+                    }
+                }
+            }
+            """
+        ).strip()
+        assert self._value(content) == 4
+
     def _value(self, content: str) -> int:
         return MvnFreeNPathMetric(
             AST.build_from_javalang(

--- a/test/metrics/npath/test_all_types.py
+++ b/test/metrics/npath/test_all_types.py
@@ -57,6 +57,15 @@ class TestMvnFreeNPathMetric:
         ).strip()
         assert self._value(content) == 0
 
+    def test_two_classes_definition(self) -> None:
+        content = dedent(
+            """\
+            class First { }
+            class Second { }
+            """
+        ).strip()
+        assert self._value(content) == 0
+
     def _value(self, content: str) -> int:
         return MvnFreeNPathMetric(
             AST.build_from_javalang(

--- a/test/metrics/npath/test_all_types.py
+++ b/test/metrics/npath/test_all_types.py
@@ -99,7 +99,7 @@ class TestMvnFreeNPathMetric:
     def test_if_with_inner_if_else(self) -> None:
         content = dedent(
             """\
-            class WithOneIf {
+            class WithOneIfWithInnerIfElse {
                 public void print(bool flag, bool ok) {
                     if (flag) {
                         if (ok) {
@@ -117,27 +117,7 @@ class TestMvnFreeNPathMetric:
     def test_if_with_if_else_inside_outer_else(self) -> None:
         content = dedent(
             """\
-            class WithOneIf {
-                public void print(bool flag, bool ok) {
-                    if (flag) {
-                        System.out.println("Flag is true");
-                    } else {
-                        if (ok) {
-                            System.out.println("OK");
-                        } else {
-                            System.out.println("Not OK");
-                        }
-                    }
-                }
-            }
-            """
-        ).strip()
-        assert self._value(content) == 4
-
-    def test_if_with_if_else_inside_outer_else(self) -> None:
-        content = dedent(
-            """\
-            class WithOneIf {
+            class WithOneIfWithIfElseInElseClause {
                 public void print(bool flag, bool ok) {
                     if (flag) {
                         System.out.println("Flag is true");

--- a/test/metrics/npath/test_all_types.py
+++ b/test/metrics/npath/test_all_types.py
@@ -1,9 +1,13 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2025 Aibolit
 # SPDX-License-Identifier: MIT
 
+from textwrap import dedent
+
 import pytest
 
-from aibolit.metrics.npath.main import NPathMetric
+from aibolit.ast_framework import AST
+from aibolit.metrics.npath.main import MvnFreeNPathMetric, NPathMetric
+from aibolit.utils.ast_builder import build_ast_from_string
 
 
 def testIncorrectFormat():
@@ -42,3 +46,20 @@ def testMediumScore():
     metric = NPathMetric(file)
     res = metric.value(True)
     assert res['data'][0]['complexity'] == 12
+
+
+class TestMvnFreeNPathMetric:
+    def test_class_definition(self) -> None:
+        content = dedent(
+            """\
+            class Dummy { }
+            """
+        ).strip()
+        assert self._value(content) == 0
+
+    def _value(self, content: str) -> int:
+        return MvnFreeNPathMetric(
+            AST.build_from_javalang(
+                build_ast_from_string(content),
+            ),
+        ).value()

--- a/test/metrics/npath/test_all_types.py
+++ b/test/metrics/npath/test_all_types.py
@@ -134,6 +134,50 @@ class TestMvnFreeNPathMetric:
         ).strip()
         assert self._value(content) == 4
 
+    def test_if_with_if_else_inside_outer_else(self) -> None:
+        content = dedent(
+            """\
+            class WithOneIf {
+                public void print(bool flag, bool ok) {
+                    if (flag) {
+                        System.out.println("Flag is true");
+                    } else {
+                        if (ok) {
+                            System.out.println("OK");
+                        } else {
+                            System.out.println("Not OK");
+                        }
+                    }
+                }
+            }
+            """
+        ).strip()
+        assert self._value(content) == 4
+
+    def test_complex_with_if_else_inside_if_else_blocks(self) -> None:
+        content = dedent(
+            """\
+            class ComplexIfElse {
+                public void checkValues(int a, int b) {
+                    if (a > 0) {
+                        if (b > 0) {
+                            System.out.println("Both a and b are greater than 0");
+                        } else {
+                            System.out.println("a is greater than 0, but b is not");
+                        }
+                    } else {
+                        if (b > 0) {
+                            System.out.println("a is not greater than 0, but b is");
+                        } else {
+                            System.out.println("Neither a nor b is greater than 0");
+                        }
+                    }
+                }
+            }
+            """
+        ).strip()
+        assert self._value(content) == 6
+
     def _value(self, content: str) -> int:
         return MvnFreeNPathMetric(
             AST.build_from_javalang(

--- a/test/metrics/npath/test_all_types.py
+++ b/test/metrics/npath/test_all_types.py
@@ -114,6 +114,26 @@ class TestMvnFreeNPathMetric:
         ).strip()
         assert self._value(content) == 4
 
+    def test_if_with_if_else_inside_outer_else(self) -> None:
+        content = dedent(
+            """\
+            class WithOneIf {
+                public void print(bool flag, bool ok) {
+                    if (flag) {
+                        System.out.println("Flag is true");
+                    } else {
+                        if (ok) {
+                            System.out.println("OK");
+                        } else {
+                            System.out.println("Not OK");
+                        }
+                    }
+                }
+            }
+            """
+        ).strip()
+        assert self._value(content) == 4
+
     def _value(self, content: str) -> int:
         return MvnFreeNPathMetric(
             AST.build_from_javalang(

--- a/test/metrics/npath/test_all_types.py
+++ b/test/metrics/npath/test_all_types.py
@@ -66,6 +66,20 @@ class TestMvnFreeNPathMetric:
         ).strip()
         assert self._value(content) == 0
 
+    def test_one_if_statement(self) -> None:
+        content = dedent(
+            """\
+            class WithOneIf {
+                public void print(bool flag) {
+                    if (flag) {
+                        System.out.println("OK");
+                    }
+                }
+            }
+            """
+        ).strip()
+        assert self._value(content) == 2
+
     def _value(self, content: str) -> int:
         return MvnFreeNPathMetric(
             AST.build_from_javalang(


### PR DESCRIPTION
In this PR we added a new class `MvnFreeNPathMetric`, which implements computation of NPath metric, without using an external process, as opposed to the original `NPathMetric` implementation.
Until `MvnFreeNPathMetric` fully implements all language constructs we must keep `NPathMetric` as it is now.
Then we will use `MvnFreeNPathMetric` as a part of `NPathMetric`.

Closes #798 