### PR TITLE
Bind `ty` version to `0.0.1-alpha.8`

### DIFF
--- a/.github/workflows/ty.yml
+++ b/.github/workflows/ty.yml
@@ -35,4 +35,4 @@ jobs:
       - name: Run Ty
         run: |
           source .venv/bin/activate
-          uvx ty check
+          uvx ty==0.0.1-alpha.8 check


### PR DESCRIPTION
Closes: #826


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow to use a specific version of the Ty type checker for improved consistency in automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->