### PR TITLE
Use pytest-testmon to speed up tests in local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@
 .Python
 .ropeproject
 .ruff_cache/
+.testmondata*
 .tox/
 .venv
 .vscode/

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ install:
 	python3 aibolit --version
 
 test:
-	python3 -m pytest --cov=aibolit/ test/
+	python3 -m pytest --testmon --cov=aibolit/ test/
 
 it:
 	python3 -m test.integration.test_patterns_and_metrics

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ pebble==4.5.3
 pylint==3.3.7
 pytest==8.3.5
 pytest-cov==6.1.1
+pytest-testmon==2.1.3
 ruff==0.11.11
 scikit-learn==1.6.1
 scipy==1.15.3


### PR DESCRIPTION
Improve performance between test runs. With `--testmon` the only affected by code changes tests will be executed.

```shell
time make test
python3 -m pytest --testmon --cov=aibolit/ test/
...
real    0m1.773s
user    0m4.351s
sys     0m0.193s
```

See: https://testmon.org/

#696

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated `.gitignore` to exclude files related to test monitoring.
  - Added `pytest-testmon` as a new dependency.
  - Modified test commands to include test monitoring functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->