### PR TITLE
Drop irrelevant puzzle from AuthFromYaml.java

### DIFF
--- a/test/integration/check/java/com/artipie/auth/AuthFromYaml.java
+++ b/test/integration/check/java/com/artipie/auth/AuthFromYaml.java
@@ -15,12 +15,6 @@ import org.apache.commons.codec.digest.DigestUtils;
 /**
  * Authentication implementation based on yaml file with credentials.
  * @since 0.3
- * @todo #146:30min Consider adding opportunity to configure alternative login, for example:
- *  | joe:
- *  |   login: joe@mail.com
- *  |   pass: "plain:123"
- *  This configuration would mean that Joe should use his email to login instead of username. Do not
- *  forget to validate credentials, logins should be unique.
  */
 @SuppressWarnings({
     "PMD.AvoidDeeplyNestedIfStmts",


### PR DESCRIPTION
Drop irrelevant puzzle from `AuthFromYaml.java`.
The puzzle belongs to another project,
where this java file was taken from
as a part of an integration test fixture.

Closes #752

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Removed a TODO comment from the documentation to improve clarity. No changes to functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->