### PR TITLE
Metrics do not accept ast in test_config.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ First, you install it (you must have
 and [Pip](https://pip.pypa.io/en/stable/installing/) installed):
 
 ```bash
-pip3 install aibolit==
+pip3 install aibolit
 ```
 
 To analyze your Java sources, located at `src/java` (for example), run:

--- a/test/config/test_config.py
+++ b/test/config/test_config.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2025 Aibolit
 # SPDX-License-Identifier: MIT
 import inspect
-import pytest
 
 from aibolit.ast_framework.ast import AST
 from aibolit.config import Config

--- a/test/config/test_config.py
+++ b/test/config/test_config.py
@@ -23,7 +23,7 @@ def test_each_metric_in_config_accepts_ast():
 
 
 def is_ast_or_subclass(ann):
-    if ann is inspect._empty:
+    if ann is inspect.Signature.empty:
         return False
     if isinstance(ann, str):
         return ann == 'AST' or ann.endswith('.AST')

--- a/test/config/test_config.py
+++ b/test/config/test_config.py
@@ -17,7 +17,8 @@ def test_each_metric_in_config_accepts_ast():
         assert 'ast' in metric_signature.parameters
         ann = metric_signature.parameters['ast'].annotation
         assert is_ast_or_subclass(ann), (
-            f"{metric_config['name']} metric.value 'ast' parameter should be typed as AST or subclass"
+            f"{metric_config['name']} "
+            f"metric.value 'ast' parameter should be typed as AST or subclass"
         )
 
 
@@ -25,7 +26,7 @@ def is_ast_or_subclass(ann):
     if ann is inspect._empty:
         return False
     if isinstance(ann, str):
-        return ann == "AST" or ann.endswith(".AST")
+        return ann == 'AST' or ann.endswith('.AST')
     try:
         return issubclass(ann, AST)
     except TypeError:

--- a/test/config/test_config.py
+++ b/test/config/test_config.py
@@ -7,24 +7,30 @@ from aibolit.ast_framework.ast import AST
 from aibolit.config import Config
 
 
-@pytest.mark.xfail
 def test_each_metric_in_config_accepts_ast():
-    '''
-    TODO #813:30min/DEV Ensure All Metrics Accept `ast: AST` Parameter with Type Hints
-    Verify that all metrics in the config accept an AST parameter with proper type hints.
-    Probable solutions:
-    1. Every metric factory in patterns_config["metrics"] produces a metric with:
-       - A parameter named "ast" in its call signature
-       - The "ast" parameter properly annotated as `aibolit.ast_framework.ast.AST` or a subclass
-    2. Remove any metrics that cannot comply with this interface.
-    Once all metrics meet requirements, remove the decorator.
-    '''
     patterns_config = Config.get_patterns_config()
+    metrics_exclude = set(patterns_config.get('metrics_exclude', []))
     for metric_config in patterns_config['metrics']:
+        if metric_config['code'] in metrics_exclude:
+            continue
         metric = metric_config['make']()
         metric_signature = inspect.signature(metric.value)
         assert 'ast' in metric_signature.parameters
-        assert metric_signature.parameters['ast'].annotation is AST
+        ann = metric_signature.parameters['ast'].annotation
+        assert is_ast_or_subclass(ann), (
+            f"{metric_config['name']} metric.value 'ast' parameter should be typed as AST or subclass"
+        )
+
+
+def is_ast_or_subclass(ann):
+    if ann is inspect._empty:
+        return False
+    if isinstance(ann, str):
+        return ann == "AST" or ann.endswith(".AST")
+    try:
+        return issubclass(ann, AST)
+    except TypeError:
+        return False
 
 
 def test_each_pattern_in_config_accepts_ast():


### PR DESCRIPTION
https://github.com/cqfn/aibolit/issues/829


fix test test_each_metric_in_config_accepts_ast
for accepting by config an AST parameter with proper type hints

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the installation command in the README for the `aibolit` package.
- **Tests**
  - Enhanced configuration metric tests by refining type annotation checks and excluding specified metrics from assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->