### PR TITLE
Refactor assert_in_code test to use inline Java

### DIFF
--- a/aibolit/ast_framework/ast.py
+++ b/aibolit/ast_framework/ast.py
@@ -14,7 +14,6 @@ from aibolit.ast_framework._auxiliary_data import (
     javalang_to_ast_node_type, attributes_by_node_type, ASTNodeReference
 )
 from aibolit.ast_framework.ast_node import ASTNode
-from aibolit.utils.ast_builder import build_ast_from_string
 
 MethodInvocationParams = namedtuple('MethodInvocationParams', ['object_name', 'method_name'])
 
@@ -42,10 +41,6 @@ class AST:
                                                    javalang_node_to_index_map)
         AST._replace_javalang_nodes_in_attributes(tree, javalang_node_to_index_map)
         return AST(tree, root)
-
-    @staticmethod
-    def from_string(content: str) -> 'AST':
-        return AST.build_from_javalang(build_ast_from_string(content))
 
     def __str__(self) -> str:
         printed_graph = ''

--- a/aibolit/ast_framework/ast.py
+++ b/aibolit/ast_framework/ast.py
@@ -14,6 +14,7 @@ from aibolit.ast_framework._auxiliary_data import (
     javalang_to_ast_node_type, attributes_by_node_type, ASTNodeReference
 )
 from aibolit.ast_framework.ast_node import ASTNode
+from aibolit.utils.ast_builder import build_ast_from_string
 
 MethodInvocationParams = namedtuple('MethodInvocationParams', ['object_name', 'method_name'])
 
@@ -41,6 +42,10 @@ class AST:
                                                    javalang_node_to_index_map)
         AST._replace_javalang_nodes_in_attributes(tree, javalang_node_to_index_map)
         return AST(tree, root)
+
+    @staticmethod
+    def from_string(content: str) -> 'AST':
+        return AST.build_from_javalang(build_ast_from_string(content))
 
     def __str__(self) -> str:
         printed_graph = ''

--- a/test/patterns/assert_in_code/Book.java
+++ b/test/patterns/assert_in_code/Book.java
@@ -1,8 +1,0 @@
-// SPDX-FileCopyrightText: Copyright (c) 2019-2025 Aibolit
-// SPDX-License-Identifier: MIT
-
-class Book {
-  void foo(String x) {
-    assert x != null; // here
-  }
-}

--- a/test/patterns/assert_in_code/test_assert_in_code.py
+++ b/test/patterns/assert_in_code/test_assert_in_code.py
@@ -6,6 +6,7 @@ from unittest import TestCase
 
 from aibolit.ast_framework import AST
 from aibolit.patterns.assert_in_code.assert_in_code import AssertInCode
+from aibolit.utils.ast_builder import build_ast_from_string
 
 
 def book_content() -> str:
@@ -16,7 +17,7 @@ def book_content() -> str:
 
         class Book {
           void foo(String x) {
-            assert x != null;
+            assert x != null; // here
           }
         }
         '''
@@ -26,5 +27,5 @@ def book_content() -> str:
 class AssertInCodeTestCase(TestCase):
 
     def test_assert_in_code(self):
-        ast = AST.from_string(book_content())
+        ast = AST.build_from_javalang(build_ast_from_string(book_content()))
         self.assertEqual(AssertInCode().value(ast), [6])

--- a/test/patterns/assert_in_code/test_assert_in_code.py
+++ b/test/patterns/assert_in_code/test_assert_in_code.py
@@ -1,19 +1,30 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2025 Aibolit
 # SPDX-License-Identifier: MIT
 
-import os.path
-from pathlib import Path
+from textwrap import dedent
 from unittest import TestCase
 
-from aibolit.patterns.assert_in_code.assert_in_code import AssertInCode
 from aibolit.ast_framework import AST
-from aibolit.utils.ast_builder import build_ast
+from aibolit.patterns.assert_in_code.assert_in_code import AssertInCode
+
+
+def book_content() -> str:
+    return dedent(
+        '''\
+        // SPDX-FileCopyrightText: Copyright (c) 2019-2025 Aibolit
+        // SPDX-License-Identifier: MIT
+
+        class Book {
+          void foo(String x) {
+            assert x != null;
+          }
+        }
+        '''
+    )
 
 
 class AssertInCodeTestCase(TestCase):
-    cur_file_dir = Path(os.path.realpath(__file__)).parent
 
     def test_assert_in_code(self):
-        file = Path(self.cur_file_dir, 'Book.java')
-        ast = AST.build_from_javalang(build_ast(file))
+        ast = AST.from_string(book_content())
         self.assertEqual(AssertInCode().value(ast), [6])


### PR DESCRIPTION
https://github.com/cqfn/aibolit/issues/692

Refactor assert_in_code test: use inline Java code and AST.from_string; remove Book.java file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated tests to use inline Java code instead of relying on external files, improving test reliability and portability.

* **Chores**
  * Removed an obsolete Java test file no longer needed for testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->