### PR TITLE
Change strict to compatible version for aibolit package installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ First, you install it (you must have
 and [Pip](https://pip.pypa.io/en/stable/installing/) installed):
 
 ```bash
-pip3 install aibolit==1.3.0
+pip3 install aibolit~=1.3.0
 ```
 
 To analyze your Java sources, located at `src/java` (for example), run:


### PR DESCRIPTION
Closes #869

- [x\] Changed `aibolit` package installation version from strict `==` to compatible `~=`

## Why This Change?
The current installation command pins to an exact version (`aibolit==1.3.0`). 
This change uses the [compatible release specifier](https://pip.pypa.io/en/stable/reference/requirement-specifiers/#compatible-release) (`~=1.3.0`) to:

1. **Automatically get patches**: Users receive bug/security fixes (`1.3.1`, `1.3.2`, etc.)
2. **Prevent breaking changes**: Blocks upgrades to future minor versions (`1.4.0+`) that might require code changes
3. **Follow packaging best practices**: Matches Python's semantic versioning conventions

| Before (`==1.3.0`) | After (`~=1.3.0`) |
|--------------------|-------------------|
| :-1: Stuck at exact version | :+1: Gets `1.3.x` patches |
| :-1: Misses critical fixes | :+1:  Security/bug fixes flow in |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to allow installing the latest compatible version of the `aibolit` package, rather than restricting to a single version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->