### PR TITLE
Add link for Ruby download page

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ First, you need to install:
 
 * [Python 3.11+](https://www.python.org/downloads/)
 * [uv](https://docs.astral.sh/uv/)
-* Ruby 2.6+
+* [Ruby 2.6+](https://www.ruby-lang.org/en/downloads/)
 * [Xcop](https://github.com/yegor256/xcop)
 
 Install the following packages if you don't have them:


### PR DESCRIPTION
Edit only README.md. Add a link to the official English download page for the Ruby language.

Before:
```md
* Ruby 2.6+
```

After:
```md
* [Ruby 2.6+](https://www.ruby-lang.org/en/downloads/)
```