### PR TITLE
Add LaTeX installation references to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,8 @@ First, you need to install:
 * Ruby 2.6+
 * [Xcop](https://github.com/yegor256/xcop)
 * [LaTeX](https://www.latex-project.org/get/)
-  * Or check out for `latexmk` LaTeX ecosystem package (**LaTeX is still needed!**): 
+  * Or check out for `latexmk` LaTeX ecosystem package
+    (**LaTeX is still needed!**):
     [Package latexmk on CTAN](https://ctan.org/pkg/latexmk)
 
 Install the following packages if you don't have them:

--- a/README.md
+++ b/README.md
@@ -320,6 +320,9 @@ First, you need to install:
 * [uv](https://docs.astral.sh/uv/)
 * Ruby 2.6+
 * [Xcop](https://github.com/yegor256/xcop)
+* [LaTeX](https://www.latex-project.org/get/)
+  * Or check out for `latexmk` LaTeX ecosystem package (**LaTeX is still needed!**): [Package latexmk on CTAN](https://ctan.org/pkg/latexmk)
+
 
 Install the following packages if you don't have them:
 

--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ First, you need to install:
 * [uv](https://docs.astral.sh/uv/)
 * Ruby 2.6+
 * [Xcop](https://github.com/yegor256/xcop)
-* [LaTeX](https://www.latex-project.org/get/) and 
+* [LaTeX](https://www.latex-project.org/get/) and
   [`latexmk`](https://ctan.org/pkg/latexmk)
 
 Install the following packages if you don't have them:

--- a/README.md
+++ b/README.md
@@ -321,8 +321,8 @@ First, you need to install:
 * Ruby 2.6+
 * [Xcop](https://github.com/yegor256/xcop)
 * [LaTeX](https://www.latex-project.org/get/)
-  * Or check out for `latexmk` LaTeX ecosystem package (**LaTeX is still needed!**): [Package latexmk on CTAN](https://ctan.org/pkg/latexmk)
-
+  * Or check out for `latexmk` LaTeX ecosystem package (**LaTeX is still needed!**): 
+    [Package latexmk on CTAN](https://ctan.org/pkg/latexmk)
 
 Install the following packages if you don't have them:
 

--- a/README.md
+++ b/README.md
@@ -320,10 +320,8 @@ First, you need to install:
 * [uv](https://docs.astral.sh/uv/)
 * Ruby 2.6+
 * [Xcop](https://github.com/yegor256/xcop)
-* [LaTeX](https://www.latex-project.org/get/)
-  * Or check out for `latexmk` LaTeX ecosystem package
-    (**LaTeX is still needed!**):
-    [Package latexmk on CTAN](https://ctan.org/pkg/latexmk)
+* [LaTeX](https://www.latex-project.org/get/) and 
+  [`latexmk`](https://ctan.org/pkg/latexmk)
 
 Install the following packages if you don't have them:
 


### PR DESCRIPTION
Closes #872 

- [x\] Added official documentation links for building the white paper

### Why This Change?
1. **Faster setup**: Contributors can directly go for links and install dependencies quicker
2. **Avoid confusion**: Clarifies which sources to use
3. **Authoritative sources**: Links to official CTAN/latex-project.org

| Before | After |
|--------|-------|
| ❌ Undocumented LaTeX requirement | ✅ Clear prerequisite note |
| ❌ No official links for LaTeX | ✅ Direct CTAN/LaTeX references |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the contribution guidelines to include LaTeX and the latexmk package as required prerequisites, with relevant links for installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->