### PR TITLE
MvnFreeNPathMetric now accounts for ternary expressions

### DIFF
--- a/aibolit/metrics/npath/main.py
+++ b/aibolit/metrics/npath/main.py
@@ -159,12 +159,14 @@ class MvnFreeNPathMetric:
         return condition_npath + body_npath + 1
 
     def _expression_npath(self, node: ASTNode) -> int:
+        def default_handler(node: ASTNode) -> int:
+            return self._composite_expression_npath(node)
+
         dispatcher = {
             ASTNodeType.BINARY_OPERATION: self._binary_expression_npath,
             ASTNodeType.TERNARY_EXPRESSION: self._ternary_npath,
         }
-        return dispatcher.get(node.node_type,
-                              self._composite_expression_npath)(node)
+        return dispatcher.get(node.node_type, default_handler)(node)
 
     def _composite_expression_npath(self, node: ASTNode) -> int:
         return sum(self._expression_npath(child) for child in node.children)

--- a/aibolit/metrics/npath/main.py
+++ b/aibolit/metrics/npath/main.py
@@ -113,6 +113,7 @@ class MvnFreeNPathMetric:
             ASTNodeType.WHILE_STATEMENT: self._while_loop_npath,
             ASTNodeType.BINARY_OPERATION: self._binary_expression_npath,
             ASTNodeType.EXPRESSION: self._expression_npath,
+            ASTNodeType.TERNARY_EXPRESSION: self._ternary_npath,
         }
 
         handler = dispatcher.get(node.node_type, default_handler)
@@ -158,11 +159,20 @@ class MvnFreeNPathMetric:
         return condition_npath + body_npath + 1
 
     def _expression_npath(self, node: ASTNode) -> int:
-        if node.node_type == ASTNodeType.BINARY_OPERATION:
-            return self._binary_expression_npath(node)
+        dispatcher = {
+            ASTNodeType.BINARY_OPERATION: self._binary_expression_npath,
+            ASTNodeType.TERNARY_EXPRESSION: self._ternary_npath,
+        }
+        return dispatcher.get(node.node_type,
+                              self._composite_expression_npath)(node)
+
+    def _composite_expression_npath(self, node: ASTNode) -> int:
         return sum(self._expression_npath(child) for child in node.children)
 
     def _binary_expression_npath(self, node: ASTNode) -> int:
         left_npath = self._expression_npath(node.operandl)
         right_npath = self._expression_npath(node.operandr)
         return left_npath + right_npath + (node.operator in ('&&', '||'))
+
+    def _ternary_npath(self, node: ASTNode) -> int:
+        return self._composite_expression_npath(node) + 2

--- a/aibolit/metrics/npath/main.py
+++ b/aibolit/metrics/npath/main.py
@@ -111,9 +111,9 @@ class MvnFreeNPathMetric:
             ASTNodeType.SWITCH_STATEMENT: self._switch_npath,
             ASTNodeType.FOR_STATEMENT: self._for_loop_npath,
             ASTNodeType.WHILE_STATEMENT: self._while_loop_npath,
-            ASTNodeType.BINARY_OPERATION: self._binary_expression_npath,
             ASTNodeType.EXPRESSION: self._expression_npath,
-            ASTNodeType.TERNARY_EXPRESSION: self._ternary_npath,
+            ASTNodeType.BINARY_OPERATION: self._expression_npath,
+            ASTNodeType.TERNARY_EXPRESSION: self._expression_npath,
         }
 
         handler = dispatcher.get(node.node_type, default_handler)

--- a/test/metrics/npath/test_all_types.py
+++ b/test/metrics/npath/test_all_types.py
@@ -570,6 +570,18 @@ class TestMvnFreeNPathMetric:
         ''').strip()
         assert self._value(content) == 5
 
+    def test_ternary_with_more_logic(self) -> None:
+        content = dedent('''
+        public class Test {
+            void method() {
+                int a = 5, b = 6, c = 4;
+                System.out.println(a < b || a < c ? (c < b ? c : a) :
+                                   (a > 3 && b < c || c < a ? 8 : 10));
+            }
+        }
+        ''').strip()
+        assert self._value(content) == 9
+
     def _filepath(self, basename: str) -> pathlib.Path:
         return pathlib.Path(__file__).parent / basename
 

--- a/test/metrics/npath/test_all_types.py
+++ b/test/metrics/npath/test_all_types.py
@@ -548,6 +548,28 @@ class TestMvnFreeNPathMetric:
     def test_even_more_complicated(self) -> None:
         assert self._value_from_filepath(self._filepath('Foo.java')) == 288
 
+    def test_ternary_trivial(self) -> None:
+        content = dedent('''
+        public class Test {
+            void method() {
+                int a = 5, b = 6;
+                System.out.println(a < b ? a : b);
+            }
+        }
+        ''').strip()
+        assert self._value(content) == 2
+
+    def test_ternary_with_logic(self) -> None:
+        content = dedent('''
+        public class Test {
+            void method() {
+                int a = 5, b = 6, c = 4;
+                System.out.println(a < b || a < c ? (c < b ? c : a) : b);
+            }
+        }
+        ''').strip()
+        assert self._value(content) == 5
+
     def _filepath(self, basename: str) -> pathlib.Path:
         return pathlib.Path(__file__).parent / basename
 


### PR DESCRIPTION
I implemented adding 2 points of NPath complexity per every ternary operator and added 2 tests.

Closes #868 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for handling ternary expressions in NPath complexity calculations.
* **Tests**
  * Introduced new tests to verify NPath complexity for Java code with ternary expressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->