### PR TITLE
Drop deprecated methods in `ast_framework.ast.AST`

### DIFF
--- a/aibolit/ast_framework/ast.py
+++ b/aibolit/ast_framework/ast.py
@@ -157,14 +157,6 @@ class AST:
             if len(types) == 0 or self._tree.nodes[node]['node_type'] in types:
                 yield ASTNode(self._tree, node)
 
-    @deprecated(reason='Use ASTNode functionality instead.')
-    def binary_operation_params(self, binary_operation_node: int) -> BinaryOperationParams:
-        assert self.type(binary_operation_node) == ASTNodeType.BINARY_OPERATION
-        operation_node, left_side_node, right_side_node = self._tree.succ[binary_operation_node]
-        return BinaryOperationParams(
-            self.attr(operation_node, 'string'), left_side_node, right_side_node
-        )
-
     @staticmethod
     def _add_subtree_from_javalang_node(tree: DiGraph, javalang_node: Union[Node, Set[Any], str],
                                         javalang_node_to_index_map: Dict[Node, int]) -> int:

--- a/aibolit/ast_framework/ast.py
+++ b/aibolit/ast_framework/ast.py
@@ -152,14 +152,6 @@ class AST:
             elif edge_type == 'reverse':
                 on_node_leaving(ASTNode(self._tree, destination))
 
-    @deprecated(reason='Use ASTNode functionality instead.')
-    def line_number_from_children(self, node: int) -> int:
-        for child in self._tree.succ[node]:
-            cur_line = self.attr(child, 'line')
-            if cur_line is not None:
-                return cur_line
-        return 0
-
     @deprecated(reason='Use get_proxy_nodes instead.')
     def nodes(self, type: Union[ASTNodeType, None] = None) -> Iterator[int]:
         for node in self._tree.nodes:

--- a/aibolit/ast_framework/ast.py
+++ b/aibolit/ast_framework/ast.py
@@ -153,12 +153,6 @@ class AST:
                 on_node_leaving(ASTNode(self._tree, destination))
 
     @deprecated(reason='Use ASTNode functionality instead.')
-    def binary_operation_name(self, node: int) -> str:
-        assert self.type(node) == ASTNodeType.BINARY_OPERATION
-        name_node, = islice(self.children_with_type(node, ASTNodeType.STRING), 1)
-        return self.attr(name_node, 'string')
-
-    @deprecated(reason='Use ASTNode functionality instead.')
     def line_number_from_children(self, node: int) -> int:
         for child in self._tree.succ[node]:
             cur_line = self.attr(child, 'line')

--- a/aibolit/ast_framework/ast.py
+++ b/aibolit/ast_framework/ast.py
@@ -153,20 +153,6 @@ class AST:
                 on_node_leaving(ASTNode(self._tree, destination))
 
     @deprecated(reason='Use ASTNode functionality instead.')
-    def first_n_children_with_type(
-        self, node: int, child_type: ASTNodeType, quantity: int
-    ) -> List[int]:
-        """
-        Returns first quantity of children of node with type child_type.
-        Resulted list is padded with None to length quantity.
-        """
-        children_with_type = (
-            child for child in self._tree.succ[node] if self.type(child) == child_type
-        )
-        children_with_type_padded = chain(children_with_type, repeat(None))
-        return list(islice(children_with_type_padded, 0, quantity))
-
-    @deprecated(reason='Use ASTNode functionality instead.')
     def binary_operation_name(self, node: int) -> str:
         assert self.type(node) == ASTNodeType.BINARY_OPERATION
         name_node, = islice(self.children_with_type(node, ASTNodeType.STRING), 1)

--- a/aibolit/ast_framework/ast.py
+++ b/aibolit/ast_framework/ast.py
@@ -153,15 +153,6 @@ class AST:
                 on_node_leaving(ASTNode(self._tree, destination))
 
     @deprecated(reason='Use ASTNode functionality instead.')
-    def children_with_type(self, node: int, child_type: ASTNodeType) -> Iterator[int]:
-        """
-        Yields children of node with given type.
-        """
-        for child in self._tree.succ[node]:
-            if self._tree.nodes[child]['node_type'] == child_type:
-                yield child
-
-    @deprecated(reason='Use ASTNode functionality instead.')
     def list_all_children_with_type(self, node: int, child_type: ASTNodeType) -> List[int]:
         list_node: List[int] = []
         for child in self._tree.succ[node]:

--- a/aibolit/ast_framework/ast.py
+++ b/aibolit/ast_framework/ast.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MIT
 
 from collections import namedtuple
-from itertools import islice, repeat, chain
 from typing import Union, Any, Callable, Set, List, Iterator, Tuple, Dict, cast, Optional
 
 from javalang.tree import Node

--- a/aibolit/ast_framework/ast.py
+++ b/aibolit/ast_framework/ast.py
@@ -158,17 +158,6 @@ class AST:
                 yield ASTNode(self._tree, node)
 
     @deprecated(reason='Use ASTNode functionality instead.')
-    def method_invocation_params(self, invocation_node: int) -> MethodInvocationParams:
-        assert self.type(invocation_node) == ASTNodeType.METHOD_INVOCATION
-        # first two STRING nodes represent object and method names
-        children = list(self.children_with_type(invocation_node, ASTNodeType.STRING))
-        if len(children) == 1:
-            return MethodInvocationParams('', self.attr(children[0], 'string'))
-
-        return MethodInvocationParams(self.attr(children[0], 'string'),
-                                      self.attr(children[1], 'string'))
-
-    @deprecated(reason='Use ASTNode functionality instead.')
     def member_reference_params(self, member_reference_node: int) -> MemberReferenceParams:
         assert self.type(member_reference_node) == ASTNodeType.MEMBER_REFERENCE
         params = [

--- a/aibolit/ast_framework/ast.py
+++ b/aibolit/ast_framework/ast.py
@@ -153,15 +153,6 @@ class AST:
                 on_node_leaving(ASTNode(self._tree, destination))
 
     @deprecated(reason='Use ASTNode functionality instead.')
-    def list_all_children_with_type(self, node: int, child_type: ASTNodeType) -> List[int]:
-        list_node: List[int] = []
-        for child in self._tree.succ[node]:
-            list_node = list_node + self.list_all_children_with_type(child, child_type)
-            if self._tree.nodes[child]['node_type'] == child_type:
-                list_node.append(child)
-        return sorted(list_node)
-
-    @deprecated(reason='Use ASTNode functionality instead.')
     def all_children_with_type(self, node: int, child_type: ASTNodeType) -> Iterator[int]:
         """
         Yields all children of node with given type.

--- a/aibolit/ast_framework/ast.py
+++ b/aibolit/ast_framework/ast.py
@@ -158,10 +158,6 @@ class AST:
                 yield ASTNode(self._tree, node)
 
     @deprecated(reason='Use ASTNode functionality instead.')
-    def type(self, node: int) -> ASTNodeType:
-        return self.attr(node, 'node_type')
-
-    @deprecated(reason='Use ASTNode functionality instead.')
     def method_invocation_params(self, invocation_node: int) -> MethodInvocationParams:
         assert self.type(invocation_node) == ASTNodeType.METHOD_INVOCATION
         # first two STRING nodes represent object and method names

--- a/aibolit/ast_framework/ast.py
+++ b/aibolit/ast_framework/ast.py
@@ -152,12 +152,6 @@ class AST:
             elif edge_type == 'reverse':
                 on_node_leaving(ASTNode(self._tree, destination))
 
-    @deprecated(reason='Use get_proxy_nodes instead.')
-    def nodes(self, type: Union[ASTNodeType, None] = None) -> Iterator[int]:
-        for node in self._tree.nodes:
-            if type is None or self._tree.nodes[node]['node_type'] == type:
-                yield node
-
     def proxy_nodes(self, *types: ASTNodeType) -> Iterator[ASTNode]:
         for node in self._tree.nodes:
             if len(types) == 0 or self._tree.nodes[node]['node_type'] in types:

--- a/aibolit/ast_framework/ast.py
+++ b/aibolit/ast_framework/ast.py
@@ -153,13 +153,6 @@ class AST:
                 on_node_leaving(ASTNode(self._tree, destination))
 
     @deprecated(reason='Use ASTNode functionality instead.')
-    def all_children_with_type(self, node: int, child_type: ASTNodeType) -> Iterator[int]:
-        """
-        Yields all children of node with given type.
-        """
-        yield from self.list_all_children_with_type(node, child_type)
-
-    @deprecated(reason='Use ASTNode functionality instead.')
     def first_n_children_with_type(
         self, node: int, child_type: ASTNodeType, quantity: int
     ) -> List[int]:

--- a/aibolit/ast_framework/ast.py
+++ b/aibolit/ast_framework/ast.py
@@ -158,10 +158,6 @@ class AST:
                 yield ASTNode(self._tree, node)
 
     @deprecated(reason='Use ASTNode functionality instead.')
-    def attr(self, node: int, attr_name: str, default_value: Any = None) -> Any:
-        return self._tree.nodes[node].get(attr_name, default_value)
-
-    @deprecated(reason='Use ASTNode functionality instead.')
     def type(self, node: int) -> ASTNodeType:
         return self.attr(node, 'node_type')
 

--- a/aibolit/ast_framework/ast.py
+++ b/aibolit/ast_framework/ast.py
@@ -158,33 +158,6 @@ class AST:
                 yield ASTNode(self._tree, node)
 
     @deprecated(reason='Use ASTNode functionality instead.')
-    def member_reference_params(self, member_reference_node: int) -> MemberReferenceParams:
-        assert self.type(member_reference_node) == ASTNodeType.MEMBER_REFERENCE
-        params = [
-            self.attr(child, 'string') for child in
-            self.children_with_type(member_reference_node, ASTNodeType.STRING)
-        ]
-
-        member_reference_params: MemberReferenceParams
-        if len(params) == 1:
-            member_reference_params = MemberReferenceParams(object_name='', member_name=params[0],
-                                                            unary_operator='')
-        elif len(params) == 2:
-            member_reference_params = MemberReferenceParams(
-                object_name=params[0], member_name=params[1], unary_operator=''
-            )
-        elif len(params) == 3:
-            member_reference_params = MemberReferenceParams(
-                unary_operator=params[0], object_name=params[1], member_name=params[2]
-            )
-        else:
-            raise ValueError(
-                'Node has 0 or more then 3 children with type "STRING": ' + str(params)
-            )
-
-        return member_reference_params
-
-    @deprecated(reason='Use ASTNode functionality instead.')
     def binary_operation_params(self, binary_operation_node: int) -> BinaryOperationParams:
         assert self.type(binary_operation_node) == ASTNodeType.BINARY_OPERATION
         operation_node, left_side_node, right_side_node = self._tree.succ[binary_operation_node]

--- a/aibolit/ast_framework/ast.py
+++ b/aibolit/ast_framework/ast.py
@@ -5,7 +5,6 @@ from collections import namedtuple
 from itertools import islice, repeat, chain
 from typing import Union, Any, Callable, Set, List, Iterator, Tuple, Dict, cast, Optional
 
-from deprecated import deprecated  # type: ignore
 from javalang.tree import Node
 from networkx import DiGraph, dfs_labeled_edges, dfs_preorder_nodes  # type: ignore
 

--- a/test/ast_framework/test_ast.py
+++ b/test/ast_framework/test_ast.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2025 Aibolit
 # SPDX-License-Identifier: MIT
 
-from unittest import TestCase, skip
+from unittest import TestCase
 from pathlib import Path
 from itertools import zip_longest
 
@@ -60,20 +60,6 @@ class ASTTestSuite(TestCase):
         method_field_ast = ast.with_fields_and_methods({'x'}, {'Increment'})
         self.assertEqual(self._field_names(method_field_ast), ['x'])
         self.assertEqual(self._method_names(method_field_ast), ['Increment'])
-
-    @skip('Method "get_member_reference_params" is deprecated')
-    def test_member_reference_params(self):
-        ast = self._build_ast('MemberReferencesExample.java')
-        for node, expected_params in zip_longest(ast.nodes(ASTNodeType.MEMBER_REFERENCE),
-                                                 ASTTestSuite._expected_member_reference_params):
-            self.assertEqual(ast.member_reference_params(node), expected_params)
-
-    @skip('Method "get_method_invocation_params" is deprecated')
-    def test_method_invocation_params(self):
-        ast = self._build_ast('MethodInvokeExample.java')
-        for node, expected_params in zip_longest(ast.nodes(ASTNodeType.METHOD_INVOCATION),
-                                                 ASTTestSuite._expected_method_invocation_params):
-            self.assertEqual(ast.method_invocation_params(node), expected_params)
 
     def _build_ast(self, filename: str):
         javalang_ast = build_ast(str(Path(__file__).parent.absolute() / filename))


### PR DESCRIPTION
In this PR we drop deprecated methods in `ast_framework.ast.AST`.
It turns out that all of them were dead code, since the newer `ASTNode` functionality was used instead already as suggested by the deprecation message.

Closes #885

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed deprecated and legacy methods from the AST interface to streamline and modernize the API.
* **Tests**
  * Removed outdated tests related to deprecated AST methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->