### PR TITLE
#882: Fix metric `M9` name: `Responce` -> `Response`

### DIFF
--- a/aibolit/config.py
+++ b/aibolit/config.py
@@ -227,7 +227,7 @@ class Config(metaclass=Singleton):
                 {'name': 'Max diameter of AST', 'code': 'M6', 'make': M6},
                 {'name': 'Number of variables', 'code': 'M7', 'make': M7},  # type: ignore
                 {'name': 'Number of methods', 'code': 'M8', 'make': M8},
-                {'name': 'Responce for class', 'code': 'M9', 'make': M9},
+                {'name': 'Response for class', 'code': 'M9', 'make': M9},
                 {'name': 'Fan out', 'code': 'M10', 'make': M10},
                 {'name': 'Cyclomatic Complexity', 'code': 'M11', 'make': M11},
             ],


### PR DESCRIPTION
Resolve #882 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a typo in the M9 metric display name: “Responce for class” is now “Response for class.”
  * Improves clarity and professionalism across any views, logs, reports, or exported results where this metric name appears.
  * No functional changes; calculations and behavior remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->