### PR TITLE
Add type safety to decomposition strength

### DIFF
--- a/aibolit/ast_framework/java_class_decomposition.py
+++ b/aibolit/ast_framework/java_class_decomposition.py
@@ -59,14 +59,20 @@ def is_ast_pattern(class_ast: AST, Pattern) -> bool:
 def _normalize_strength(strength: Union[DecompositionStrength, str]) -> DecompositionStrength:
     if isinstance(strength, DecompositionStrength):
         return strength
-    try:
-        return DecompositionStrength(strength.lower())
-    except ValueError as exc:
-        valid_strengths = [s.value for s in DecompositionStrength]
-        raise ValueError(
-            f'Unsupported decomposition strength: {strength}. '
-            f'Must be one of: {valid_strengths}'
-        ) from exc
+    if isinstance(strength, str):
+        try:
+            return DecompositionStrength(strength.lower())
+        except ValueError as exc:
+            valid_strengths = DecompositionStrength.values()
+            raise ValueError(
+                f'Unsupported decomposition strength: {strength}. '
+                f'Must be one of: {valid_strengths}'
+            ) from exc
+    valid_strengths = DecompositionStrength.values()
+    raise ValueError(
+        f'Unsupported decomposition strength: {strength}. '
+        f'Must be one of: {valid_strengths}'
+    )
 
 
 def decompose_java_class(


### PR DESCRIPTION
Closes the issue #883 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a typed strength option for class decomposition with two modes: strong and weak.

- Refactor
  - Decomposition API now accepts the typed option (enum or equivalent string); input is normalized, validated, and has a default.

- Documentation
  - Parameter descriptions and docstrings updated to reflect the typed strength and valid values.

- Note
  - Passing unsupported values now raises a validation error listing valid options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->