### PR TITLE
docs: #870 document scripts/target/* paths as pipeline outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,14 @@ aibolit recommend --help
 
 Train works only with cloned git repository.
 
+The training files referenced below under `target/01/...`,
+`target/08/08-train.csv`, and `target/08/08-test.csv` are not shipped with
+the repository. They are produced by the pipeline in `scripts/`:
+`01-fetch-github.py` populates `target/01/`, and `08-split.py` writes
+`target/08/08-train.csv` and `target/08/08-test.csv`. Run `make` inside
+`scripts/` first, or supply your own dataset under the same layout,
+before invoking `aibolit train`.
+
 1. Clone aibolit repository
 2. Go to `cloned_aibolit_path`
 3. Run `pip install .`
@@ -314,6 +322,7 @@ located in `TARGET_FOLDER/target`.*
 8. **Java Files Directory** (optional):
    * To use a custom folder with Java files, use the `--java_folder` parameter
    * Default value: `scripts/target/01` of the aibolit cloned repository
+     (populated by `scripts/01-fetch-github.py`; absent on a fresh clone)
    * Usage example:
 
      ```bash


### PR DESCRIPTION
The training section of `README.md` referred to `scripts/target/01`,
`target/08/08-train.csv`, and `target/08/08-test.csv` as if they
existed in a fresh clone. They are outputs of the pipeline under
`scripts/` (`01-fetch-github.py` for `target/01/`, `08-split.py` for
the two `target/08/` CSVs) and are absent until that pipeline runs.

Adds a paragraph at the top of the "How to retrain it?" section that
names the producing scripts and points the reader at `make` inside
`scripts/`. Adds the same hint to the `--java_folder` default note in
step 8. No code paths change.

Verified with `markdownlint-cli2 README.md` (0 errors) and a line-length
scan against the project's 80-column cap (only pre-existing badge and
link lines exceed it).

Closes #870


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified setup and retraining instructions in the README.
  * Explained that the training CSV files are generated by scripts and are not stored in the repository.
  * Added guidance on how to prepare the required dataset layout before running training.
  * Noted that the `scripts/target/01` directory will be missing in a fresh clone.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->