### PR TITLE
docs: #77 document the Getter pattern in PATTERNS.md

### DIFF
--- a/PATTERNS.md
+++ b/PATTERNS.md
@@ -82,6 +82,32 @@ class Book {
 ```
 
 ***
+*Title*: Getter
+
+Description: The method's name starts with `get`, and the only statement in the body is a `return`. Asserts before the return are ignored. The pattern is implemented in `aibolit/patterns/classic_getter/classic_getter.py` and exercised by `test/patterns/classic_getter/test_classic_getter.py`.
+
+*Example*:
+
+```java
+class Book {
+  private String title;
+  public String getTitle() {
+    return this.title;
+  }
+}
+```
+
+```java
+class Book {
+  private int value;
+  public int getValue() {
+    assert this.value >= 0;
+    return value;
+  }
+}
+```
+
+***
 *Title*: Empty Rethrow
 
 *Code*: **P3**


### PR DESCRIPTION
Issue #77 asks for a clearer picture of what aibolit looks for. The `ClassicGetter` pattern in `aibolit/patterns/classic_getter/classic_getter.py` is implemented and covered by tests in `test/patterns/classic_getter/test_classic_getter.py`, but `PATTERNS.md` only documents `Setter` and leaves the symmetric getter case unmentioned.

The change adds a `Getter` section to `PATTERNS.md` next to the existing `Setter` entry, mirroring its structure: a short description that names the source and test paths, plus two minimal Java snippets covering the plain `return this.field` shape and the assert-then-return shape that the implementation explicitly allows.

Only `PATTERNS.md` is touched; no code or tests change. `make markdown-lint` ignores this file (its globs cover `README.md`), so the verification done locally was `git diff` and a plain read-through of the rendered section.

Closes #77


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added documentation for the Getter pattern, including detection rules and code examples to help developers identify and understand this design pattern in their codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->