### PR TITLE
docs: #871 indent continuation lines in training section list

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,11 +267,12 @@ Train works only with cloned git repository.
 2. Go to `cloned_aibolit_path`
 3. Run `pip install .`
 4. Set env variable `export HOME_AIBOLIT=cloned_aibolit_path` (example for
-Linux).
+   Linux).
 5. Set env variable `TARGET_FOLDER` if you need to save all dataset files to
-another directory.
-*Please note that if you set `TARGET_FOLDER`, your dataset files will be
-located in `TARGET_FOLDER/target`.*
+   another directory.
+
+   *Please note that if you set `TARGET_FOLDER`, your dataset files will be
+   located in `TARGET_FOLDER/target`.*
 6. **Dataset Paths** (required when using `TARGET_FOLDER`):
    * Set the training dataset path:
 


### PR DESCRIPTION
The training section's ordered list has continuation paragraphs for items 4 and 5 that sit at column 1. CommonMark needs them indented by the list-item content width to keep them part of the same item, so right now the renderer breaks the list and runs items together. Issue #871 reports the resulting jumbled paragraph.

Indent the "Linux)." line under item 4 and the "another directory." line under item 5 to 3 spaces, and move the parenthetical TARGET_FOLDER note to a blank-line-separated continuation paragraph under item 5. README.md is the only file touched and no headings, items, or content are renamed.

Ran `npx markdownlint-cli2 README.md` on the patched file with 0 errors, matching the workflow at `.github/workflows/markdown-lint.yml`.

Closes #871


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved formatting of retraining instructions in documentation for better readability and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->