### PR TITLE
Preserve original error context in __count_value

### DIFF
--- a/aibolit/__main__.py
+++ b/aibolit/__main__.py
@@ -137,6 +137,7 @@ def __count_value(value_dict, input_params, code_lines_dict, java_file: str, is_
     :return: None, it has side-effect
     """
     acronym = value_dict['code']
+    entity = 'metric' if is_metric else 'pattern'
     try:
         ast = AST.build_from_javalang(build_ast(java_file))
         val = value_dict['make']().value(ast)
@@ -145,9 +146,10 @@ def __count_value(value_dict, input_params, code_lines_dict, java_file: str, is_
             code_lines_dict['lines_' + acronym] = val
         else:
             input_params[acronym] = val
-    except Exception:
-        exc_type, exc_value, exc_tb = sys.exc_info()
-        raise Exception(f"Can't count {acronym} metric: {str(type(exc_value))}")
+    except Exception as exc:
+        raise RuntimeError(
+            f"Can't count {acronym} {entity} on {java_file}: {exc}"
+        ) from exc
 
 
 def flatten(lst: List[List[Any]]) -> List[Any]:

--- a/test/recommend/test_recommend_pipeline.py
+++ b/test/recommend/test_recommend_pipeline.py
@@ -4,6 +4,7 @@ import os
 from hashlib import md5
 from pathlib import Path
 from unittest import TestCase, skip
+from unittest.mock import patch
 
 import javalang
 import javalang.tree
@@ -158,6 +159,29 @@ class TestRecommendPipeline(TestCase):
         mock_input = self.__create_mock_input()
         mock_cmd = self.__create_mock_cmd()
         create_xml_tree(mock_input, full_report=True, cmd=mock_cmd, exit_code=2)
+
+    def test_count_value_keeps_original_exception_context(self):
+        from aibolit import __main__ as aibolit_main
+
+        value_dict = {
+            'code': 'P99',
+            'make': lambda: None,
+        }
+
+        with patch('aibolit.__main__.build_ast', side_effect=KeyError('missing node')):
+            with self.assertRaises(RuntimeError) as err:
+                getattr(aibolit_main, '__count_value')(
+                    value_dict,
+                    {},
+                    {},
+                    'broken/File.java',
+                )
+
+        self.assertEqual(
+            str(err.exception),
+            "Can't count P99 pattern on broken/File.java: 'missing node'",
+        )
+        self.assertIsInstance(err.exception.__cause__, KeyError)
 
     def test_text_format(self):
         mock_input = self.__create_mock_input()

--- a/test/recommend/test_recommend_pipeline.py
+++ b/test/recommend/test_recommend_pipeline.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 import javalang
 import javalang.tree
 
+from aibolit import __main__ as aibolit_main
 from aibolit.config import Config
 
 from aibolit.__main__ import list_dir, calculate_patterns_and_metrics, \
@@ -161,8 +162,6 @@ class TestRecommendPipeline(TestCase):
         create_xml_tree(mock_input, full_report=True, cmd=mock_cmd, exit_code=2)
 
     def test_count_value_keeps_original_exception_context(self):
-        from aibolit import __main__ as aibolit_main
-
         value_dict = {
             'code': 'P99',
             'make': lambda: None,


### PR DESCRIPTION
## Summary
- preserve the original exception message when `__count_value` fails
- raise `RuntimeError` with exception chaining and the analyzed file path
- add a regression test covering the preserved message and `__cause__`

## Verification
- `python3 -m pytest test/recommend/test_recommend_pipeline.py -q`

Closes #1181 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error reporting to include more detailed context, distinguishing between different item types.
  * Improved exception handling to preserve original error information while providing clearer, more informative error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->