### PR TITLE
Preserve string literals in RemoveComments

### DIFF
--- a/aibolit/utils/utils.py
+++ b/aibolit/utils/utils.py
@@ -8,86 +8,90 @@ class RemoveComments:
         pass
 
     @staticmethod
+    def _trim_comment_only_indent(result):
+        while result and result[-1] not in '\n\r':
+            if result[-1] not in ' \t':
+                return
+            result.pop()
+
+    @staticmethod
+    def _consume_comment(symbol, next_symbol, result, state):
+        if state['mode'] == 'line_comment':
+            if symbol == '\n':
+                result.append(symbol)
+                state['mode'] = None
+            return 1
+        if state['mode'] == 'block_comment':
+            if symbol == '*' and next_symbol == '/':
+                state['mode'] = None
+                return 2
+            if symbol == '\n':
+                result.append(symbol)
+            return 1
+        return 0
+
+    @staticmethod
+    def _consume_literal(symbol, state):
+        if state['mode'] not in {'string', 'char'}:
+            return False
+        if state['escaped']:
+            state['escaped'] = False
+        elif symbol == '\\':
+            state['escaped'] = True
+        elif symbol == '"' and state['mode'] == 'string':
+            state['mode'] = None
+        elif symbol == "'" and state['mode'] == 'char':
+            state['mode'] = None
+        return True
+
+    @staticmethod
+    def _enter_literal(symbol, state):
+        if symbol == '"':
+            state['mode'] = 'string'
+            state['escaped'] = False
+            return True
+        if symbol == "'":
+            state['mode'] = 'char'
+            state['escaped'] = False
+            return True
+        return False
+
+    @staticmethod
+    def _enter_comment(symbol, next_symbol, result, state):
+        if symbol != '/' or next_symbol not in {'/', '*'}:
+            return 0
+        result.pop()
+        RemoveComments._trim_comment_only_indent(result)
+        state['mode'] = 'line_comment' if next_symbol == '/' else 'block_comment'
+        return 2
+
+    @staticmethod
     def remove_comments(string):
         result = []
+        state = {'mode': None, 'escaped': False}
         index = 0
-        in_string = False
-        in_char = False
-        in_line_comment = False
-        in_block_comment = False
-        escaped = False
-
-        def trim_comment_only_indent():
-            while result and result[-1] not in '\n\r':
-                if result[-1] not in ' \t':
-                    return
-                result.pop()
-
         while index < len(string):
             symbol = string[index]
             next_symbol = string[index + 1] if index + 1 < len(string) else ''
 
-            if in_line_comment:
-                if symbol == '\n':
-                    result.append(symbol)
-                    in_line_comment = False
-                index += 1
-                continue
-
-            if in_block_comment:
-                if symbol == '*' and next_symbol == '/':
-                    in_block_comment = False
-                    index += 2
-                    continue
-                if symbol == '\n':
-                    result.append(symbol)
-                index += 1
+            step = RemoveComments._consume_comment(symbol, next_symbol, result, state)
+            if step:
+                index += step
                 continue
 
             result.append(symbol)
 
-            if in_string:
-                if escaped:
-                    escaped = False
-                elif symbol == '\\':
-                    escaped = True
-                elif symbol == '"':
-                    in_string = False
+            if RemoveComments._consume_literal(symbol, state):
                 index += 1
                 continue
 
-            if in_char:
-                if escaped:
-                    escaped = False
-                elif symbol == '\\':
-                    escaped = True
-                elif symbol == "'":
-                    in_char = False
+            if RemoveComments._enter_literal(symbol, state):
                 index += 1
                 continue
 
-            if symbol == '"':
-                in_string = True
-                index += 1
-                continue
-
-            if symbol == "'":
-                in_char = True
-                index += 1
-                continue
-
-            if symbol == '/' and next_symbol == '/':
-                result.pop()
-                trim_comment_only_indent()
-                in_line_comment = True
-                index += 2
-                continue
-
-            if symbol == '/' and next_symbol == '*':
-                result.pop()
-                trim_comment_only_indent()
-                in_block_comment = True
-                index += 2
+            step = RemoveComments._enter_comment(symbol, next_symbol, result, state)
+            if step:
+                index += step
                 continue
 
             index += 1

--- a/aibolit/utils/utils.py
+++ b/aibolit/utils/utils.py
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
 # SPDX-License-Identifier: MIT
-import re
 
 
 class RemoveComments:
@@ -10,10 +9,87 @@ class RemoveComments:
 
     @staticmethod
     def remove_comments(string):
-        # remove all occurrences streamed comments (/*COMMENT */) from string
-        string = re.sub(re.compile(r'/\*.*?\*/', re.DOTALL), '',
-                        string)
-        # remove all occurrence single-line comments (//COMMENT\n ) from string
-        string = re.sub(re.compile(r'//.*?\n'), '',
-                        string)
-        return string
+        result = []
+        index = 0
+        in_string = False
+        in_char = False
+        in_line_comment = False
+        in_block_comment = False
+        escaped = False
+
+        def trim_comment_only_indent():
+            while result and result[-1] not in '\n\r':
+                if result[-1] not in ' \t':
+                    return
+                result.pop()
+
+        while index < len(string):
+            symbol = string[index]
+            next_symbol = string[index + 1] if index + 1 < len(string) else ''
+
+            if in_line_comment:
+                if symbol == '\n':
+                    result.append(symbol)
+                    in_line_comment = False
+                index += 1
+                continue
+
+            if in_block_comment:
+                if symbol == '*' and next_symbol == '/':
+                    in_block_comment = False
+                    index += 2
+                    continue
+                if symbol == '\n':
+                    result.append(symbol)
+                index += 1
+                continue
+
+            result.append(symbol)
+
+            if in_string:
+                if escaped:
+                    escaped = False
+                elif symbol == '\\':
+                    escaped = True
+                elif symbol == '"':
+                    in_string = False
+                index += 1
+                continue
+
+            if in_char:
+                if escaped:
+                    escaped = False
+                elif symbol == '\\':
+                    escaped = True
+                elif symbol == "'":
+                    in_char = False
+                index += 1
+                continue
+
+            if symbol == '"':
+                in_string = True
+                index += 1
+                continue
+
+            if symbol == "'":
+                in_char = True
+                index += 1
+                continue
+
+            if symbol == '/' and next_symbol == '/':
+                result.pop()
+                trim_comment_only_indent()
+                in_line_comment = True
+                index += 2
+                continue
+
+            if symbol == '/' and next_symbol == '*':
+                result.pop()
+                trim_comment_only_indent()
+                in_block_comment = True
+                index += 2
+                continue
+
+            index += 1
+
+        return ''.join(result)

--- a/test/metrics/spaces/TestSpaces.py
+++ b/test/metrics/spaces/TestSpaces.py
@@ -17,7 +17,7 @@ class TestSpaces(TestCase):
 
     def test_class_with_best_ident(self):
         val = self.max_left.value(Path(self.dir_path, 'BestIdent.java'))
-        self.assertEqual(val, 44)
+        self.assertEqual(val, 12)
         val = self.max_right.value(Path(self.dir_path, 'BestIdent.java'))
         self.assertEqual(val, 113)
 
@@ -49,7 +49,7 @@ class TestSpaces(TestCase):
         val = self.max_left.value(Path(self.dir_path, 'WorstIdentation.java'))
         self.assertEqual(val, 20)
         val = self.max_right.value(Path(self.dir_path, 'WorstIdentation.java'))
-        self.assertEqual(val, 163)
+        self.assertEqual(val, 166)
 
     def test_empty_examples(self):
         val = self.max_left.value(Path(self.dir_path, 'ClusterDataSourceConfiguration.java'))

--- a/test/utils/test_remove_comments.py
+++ b/test/utils/test_remove_comments.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+# SPDX-License-Identifier: MIT
+from unittest import TestCase
+
+from aibolit.utils.utils import RemoveComments
+
+
+class TestRemoveComments(TestCase):
+
+    def test_preserves_double_slash_inside_string_literal(self):
+        source = (
+            'class A {\n'
+            '    String url = "http://example.com";\n'
+            '    int x;\n'
+            '}\n'
+        )
+
+        self.assertEqual(RemoveComments.remove_comments(source), source)
+
+    def test_preserves_literal_content_while_removing_real_comments(self):
+        source = (
+            'class A {\n'
+            '    String text = "/* tag */"; // trailing comment\n'
+            "    char slash = '/'; /* block\n"
+            '    comment */\n'
+            '}\n'
+        )
+        expected = (
+            'class A {\n'
+            '    String text = "/* tag */";\n'
+            "    char slash = '/';\n"
+            '\n'
+            '}\n'
+        )
+
+        self.assertEqual(RemoveComments.remove_comments(source), expected)


### PR DESCRIPTION
## Summary
- replace regex-based comment stripping with a small scanner that respects Java string and character literals
- preserve line breaks while removing real comments so indentation metrics keep the original line structure
- add regression coverage for `http://...` and `"/* ... */"` literals and update spacing expectations accordingly

## Verification
- `python3 -m pytest test/utils/test_remove_comments.py -q`
- `python3 -m pytest test/metrics/spaces/TestSpaces.py -q`
- `python3 -m pytest test/utils/test_encoding_detector.py -q`

Closes #1185

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved comment removal to correctly preserve comment-like content inside string and character literals and to more reliably strip real inline and block comments (including trimming comment-only line whitespace).

* **Tests**
  * Added unit tests covering preservation of literals and removal of comments.
  * Updated indentation metric test expectations to reflect corrected values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->