### PR TITLE
Fix top-level Java file collection in metrics script

### DIFF
--- a/scripts/03-calculate-metrics.py
+++ b/scripts/03-calculate-metrics.py
@@ -11,7 +11,7 @@ DIR_TO_CREATE = 'target/03'
 
 
 def create_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description='Filter important java files')
+    parser = argparse.ArgumentParser(description='Calculate metrics for Java files')
     parser.add_argument(
         '--dir',
         help='dir for Java files search',
@@ -50,22 +50,10 @@ def run_pmd(dir_to_analyze: Path) -> list[str]:
 
 
 def read_pmd_frames(csv_files: list[str]) -> list[pd.DataFrame]:
-    cur_df = pd.DataFrame(
-        [['-555', 'com.google.samples',
-          'Fake.java', '3', '11', 'The class AdViewIdlingResource', 'Design',
-          'NcssCount']],
-        columns=[
-            'Problem', 'Package', 'File', 'Priority', 'Line', 'Description',
-            'Rule set', 'Rule'
-        ]
-    )
-    cur_df.set_index('Problem')
-
     frames = []
     for csv_file in csv_files:
         try:
             new_frame = pd.read_csv(csv_file)
-            cur_df.set_index('Problem')
             frames.append(new_frame)
         except Exception:
             pass
@@ -75,7 +63,6 @@ def read_pmd_frames(csv_files: list[str]) -> list[pd.DataFrame]:
 def build_metrics(frames: list[pd.DataFrame]) -> pd.DataFrame:
     df = pd.concat(frames)
     df = df[df.Problem != -555]
-    df.set_index('Problem')
     df.to_csv('./_tmp/pmd_out.csv')
 
     df = pd.read_csv('./_tmp/pmd_out.csv')
@@ -86,8 +73,6 @@ def build_metrics(frames: list[pd.DataFrame]) -> pd.DataFrame:
         .groupby(['File', 'Rule']).filter(lambda x: len(x) > 1)['File']\
         .unique().tolist()
 
-    df[df.Rule == 'CyclomaticComplexity']['Description'].str\
-        .extract(r'complexity of (\d+)', expand=True)
     df['cyclo'] = df['Description'].str\
         .extract(r'cyclomatic complexity of (\d+)', expand=True).astype(float)
     df['ncss'] = df['Description'].str\

--- a/scripts/03-calculate-metrics.py
+++ b/scripts/03-calculate-metrics.py
@@ -7,134 +7,163 @@ from pathlib import Path
 
 import pandas as pd
 
-parser = argparse.ArgumentParser(description='Filter important java files')
-parser.add_argument(
-    '--dir',
-    help='dir for Java files search',
-    required=False
-)
-args = parser.parse_args()
-
-
 DIR_TO_CREATE = 'target/03'
-dir_to_analyze = args.dir or './target/01'
-current_location: str = os.path.realpath(
-    os.path.join(os.getcwd(), os.path.dirname(__file__))
-)
-csv_files = []
-for dir_local in Path(dir_to_analyze).iterdir():
-    if dir_local.is_dir():
-        print(f'Start metrics calculation for path {dir_local.parts[-1]}')
-        csv_filename = f'./_tmp/{dir_local.parts[-1]}_pmd_out.csv'
+
+
+def create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description='Filter important java files')
+    parser.add_argument(
+        '--dir',
+        help='dir for Java files search',
+        required=False
+    )
+    return parser
+
+
+def collect_analysis_targets(dir_to_analyze: Path) -> list[Path]:
+    return [
+        path for path in sorted(dir_to_analyze.iterdir(), key=lambda path: path.name)
+        if path.is_dir() or path.suffix == '.java'
+    ]
+
+
+def csv_filename_for_path(path: Path) -> str:
+    if path.is_dir():
+        return f'./_tmp/{path.name}_pmd_out.csv'
+    return f'./_tmp/file_{path.stem}_pmd_out.csv'
+
+
+def run_pmd(dir_to_analyze: Path) -> list[str]:
+    csv_files = []
+    for path_to_analyze in collect_analysis_targets(dir_to_analyze):
+        print(f'Start metrics calculation for path {path_to_analyze.name}')
+        csv_filename = csv_filename_for_path(path_to_analyze)
         csv_files.append(csv_filename)
-        f = open(csv_filename, 'w', encoding='utf-8')
-        subprocess.call([
-            './_tmp/pmd-bin/bin/run.sh', 'pmd',
-            '-cache', './_tmp/cache',
-            '-d', dir_local.absolute(), '-R', 'ruleset.xml', '-f', 'csv'
-        ], stdout=f)
+        with open(csv_filename, 'w', encoding='utf-8') as file_descriptor:
+            subprocess.call([
+                './_tmp/pmd-bin/bin/run.sh', 'pmd',
+                '-cache', './_tmp/cache',
+                '-d', path_to_analyze.absolute(), '-R', 'ruleset.xml', '-f', 'csv'
+            ], stdout=file_descriptor)
         print('Metrics have calculated.')
-        f.close()
+    return csv_files
 
 
-cur_df = pd.DataFrame(
-    [['-555', 'com.google.samples',
-      'Fake.java', '3', '11', 'The class AdViewIdlingResource', 'Design',
-      'NcssCount']],
-    columns=['Problem', 'Package', 'File', 'Priority', 'Line', 'Description', 'Rule set', 'Rule']
-)
-cur_df.set_index('Problem')
+def read_pmd_frames(csv_files: list[str]) -> list[pd.DataFrame]:
+    cur_df = pd.DataFrame(
+        [['-555', 'com.google.samples',
+          'Fake.java', '3', '11', 'The class AdViewIdlingResource', 'Design',
+          'NcssCount']],
+        columns=[
+            'Problem', 'Package', 'File', 'Priority', 'Line', 'Description',
+            'Rule set', 'Rule'
+        ]
+    )
+    cur_df.set_index('Problem')
 
-frames = []
-for i in csv_files:
-    try:
-        new_frame = pd.read_csv(i)
-        cur_df.set_index('Problem')
-        frames.append(new_frame)
-    except Exception:
-        pass
-
-print(f'we have {len(csv_files)} folders, {len(frames)} datasets')
-df = pd.concat(frames)
-df = df[df.Problem != -555]
-df.set_index('Problem')
-df.to_csv('./_tmp/pmd_out.csv')
-
-df = pd.read_csv('./_tmp/pmd_out.csv')
-df = df.drop(df.columns[[0]], axis=1)
-df['class'] = 0
-df.loc[df['Description'].str.contains('The class'), 'class'] = 1
-rows_to_remove = df[df['class'] == 1][['File', 'class', 'Rule']]\
-    .groupby(['File', 'Rule']).filter(lambda x: len(x) > 1)['File']\
-    .unique().tolist()
-
-df[df.Rule == 'CyclomaticComplexity']['Description'].str\
-    .extract(r'complexity of (\d+)', expand=True)
-df['cyclo'] = df['Description'].str\
-    .extract(r'cyclomatic complexity of (\d+)', expand=True).astype(float)
-df['ncss'] = df['Description'].str\
-    .extract(r'NCSS line count of (\d+)', expand=True).astype(float)
-df['npath'] = df['Description']\
-    .str.extract(r'NPath complexity of (\d+)', expand=True).astype(float)
-
-class_cyclo = df[df['class'] == 1][['File', 'cyclo']].copy().dropna()\
-    .reset_index().set_index('File')
-avg_method_cyclo = df[df['class'] == 0][['File', 'cyclo']].copy()\
-    .dropna().groupby('File').mean() \
-    .reset_index() \
-    .set_index('File') \
-    .rename({'cyclo': 'cyclo_method_avg'}, axis='columns')
-
-min_method_cyclo = df[df['class'] == 0][['File', 'cyclo']].copy().dropna()\
-    .groupby('File').min().reset_index().set_index('File')\
-    .rename({'cyclo': 'cyclo_method_min'}, axis='columns')
-max_method_cyclo = df[df['class'] == 0][['File', 'cyclo']].copy().dropna()\
-    .groupby('File').max().reset_index().set_index('File')\
-    .rename({'cyclo': 'cyclo_method_max'}, axis='columns')
-
-avg_method_npath = df[df['class'] == 0][['File', 'npath']].copy().dropna()\
-    .groupby('File').mean().reset_index().set_index('File')\
-    .rename({'npath': 'npath_method_avg'}, axis='columns')
-min_method_npath = df[df['class'] == 0][['File', 'npath']].copy().dropna()\
-    .groupby('File').min().reset_index().set_index('File')\
-    .rename({'npath': 'npath_method_min'}, axis='columns')
-max_method_npath = df[df['class'] == 0][['File', 'npath']].copy().dropna()\
-    .groupby('File').max().reset_index().set_index('File')\
-    .rename({'npath': 'npath_method_max'}, axis='columns')
-
-class_ncss = df[df['class'] == 1][['File', 'ncss']].copy().dropna()\
-    .groupby('File').sum().reset_index().set_index('File')
+    frames = []
+    for csv_file in csv_files:
+        try:
+            new_frame = pd.read_csv(csv_file)
+            cur_df.set_index('Problem')
+            frames.append(new_frame)
+        except Exception:
+            pass
+    return frames
 
 
-avg_method_ncss = df[df['class'] == 0][['File', 'ncss']].copy().dropna()\
-    .groupby('File').mean().reset_index().set_index('File')\
-    .rename({'ncss': 'ncss_method_avg'}, axis='columns')
-min_method_ncss = df[df['class'] == 0][['File', 'ncss']].copy().dropna()\
-    .groupby('File').min().reset_index().set_index('File')\
-    .rename({'ncss': 'ncss_method_min'}, axis='columns')
-max_method_ncss = df[df['class'] == 0][['File', 'ncss']].copy().dropna()\
-    .groupby('File').max().reset_index().set_index('File')\
-    .rename({'ncss': 'ncss_method_max'}, axis='columns')
+def build_metrics(frames: list[pd.DataFrame]) -> pd.DataFrame:
+    df = pd.concat(frames)
+    df = df[df.Problem != -555]
+    df.set_index('Problem')
+    df.to_csv('./_tmp/pmd_out.csv')
 
-keys = pd.DataFrame(df.File.unique(), columns=['File']).set_index('File')
-keys = keys.drop(rows_to_remove, axis=0)
-metrics = keys.join(class_cyclo, how='inner')\
-    .join(avg_method_cyclo, how='left')\
-    .drop(columns=['index'])\
-    .join(min_method_cyclo, how='left')\
-    .join(max_method_cyclo, how='left')\
-    .join(avg_method_npath, how='left')\
-    .join(min_method_npath, how='left')\
-    .join(max_method_npath, how='left')\
-    .join(class_ncss, how='left')\
-    .join(avg_method_ncss, how='left')\
-    .join(min_method_ncss, how='left')\
-    .join(max_method_ncss, how='left')\
-    .reset_index()\
-    .rename({'File': 'filename'}, axis='columns')\
+    df = pd.read_csv('./_tmp/pmd_out.csv')
+    df = df.drop(df.columns[[0]], axis=1)
+    df['class'] = 0
+    df.loc[df['Description'].str.contains('The class'), 'class'] = 1
+    rows_to_remove = df[df['class'] == 1][['File', 'class', 'Rule']]\
+        .groupby(['File', 'Rule']).filter(lambda x: len(x) > 1)['File']\
+        .unique().tolist()
+
+    df[df.Rule == 'CyclomaticComplexity']['Description'].str\
+        .extract(r'complexity of (\d+)', expand=True)
+    df['cyclo'] = df['Description'].str\
+        .extract(r'cyclomatic complexity of (\d+)', expand=True).astype(float)
+    df['ncss'] = df['Description'].str\
+        .extract(r'NCSS line count of (\d+)', expand=True).astype(float)
+    df['npath'] = df['Description']\
+        .str.extract(r'NPath complexity of (\d+)', expand=True).astype(float)
+
+    class_cyclo = df[df['class'] == 1][['File', 'cyclo']].copy().dropna()\
+        .reset_index().set_index('File')
+    avg_method_cyclo = df[df['class'] == 0][['File', 'cyclo']].copy()\
+        .dropna().groupby('File').mean() \
+        .reset_index() \
+        .set_index('File') \
+        .rename({'cyclo': 'cyclo_method_avg'}, axis='columns')
+
+    min_method_cyclo = df[df['class'] == 0][['File', 'cyclo']].copy().dropna()\
+        .groupby('File').min().reset_index().set_index('File')\
+        .rename({'cyclo': 'cyclo_method_min'}, axis='columns')
+    max_method_cyclo = df[df['class'] == 0][['File', 'cyclo']].copy().dropna()\
+        .groupby('File').max().reset_index().set_index('File')\
+        .rename({'cyclo': 'cyclo_method_max'}, axis='columns')
+
+    avg_method_npath = df[df['class'] == 0][['File', 'npath']].copy().dropna()\
+        .groupby('File').mean().reset_index().set_index('File')\
+        .rename({'npath': 'npath_method_avg'}, axis='columns')
+    min_method_npath = df[df['class'] == 0][['File', 'npath']].copy().dropna()\
+        .groupby('File').min().reset_index().set_index('File')\
+        .rename({'npath': 'npath_method_min'}, axis='columns')
+    max_method_npath = df[df['class'] == 0][['File', 'npath']].copy().dropna()\
+        .groupby('File').max().reset_index().set_index('File')\
+        .rename({'npath': 'npath_method_max'}, axis='columns')
+
+    class_ncss = df[df['class'] == 1][['File', 'ncss']].copy().dropna()\
+        .groupby('File').sum().reset_index().set_index('File')
+
+    avg_method_ncss = df[df['class'] == 0][['File', 'ncss']].copy().dropna()\
+        .groupby('File').mean().reset_index().set_index('File')\
+        .rename({'ncss': 'ncss_method_avg'}, axis='columns')
+    min_method_ncss = df[df['class'] == 0][['File', 'ncss']].copy().dropna()\
+        .groupby('File').min().reset_index().set_index('File')\
+        .rename({'ncss': 'ncss_method_min'}, axis='columns')
+    max_method_ncss = df[df['class'] == 0][['File', 'ncss']].copy().dropna()\
+        .groupby('File').max().reset_index().set_index('File')\
+        .rename({'ncss': 'ncss_method_max'}, axis='columns')
+
+    keys = pd.DataFrame(df.File.unique(), columns=['File']).set_index('File')
+    keys = keys.drop(rows_to_remove, axis=0)
+    return keys.join(class_cyclo, how='inner')\
+        .join(avg_method_cyclo, how='left')\
+        .drop(columns=['index'])\
+        .join(min_method_cyclo, how='left')\
+        .join(max_method_cyclo, how='left')\
+        .join(avg_method_npath, how='left')\
+        .join(min_method_npath, how='left')\
+        .join(max_method_npath, how='left')\
+        .join(class_ncss, how='left')\
+        .join(avg_method_ncss, how='left')\
+        .join(min_method_ncss, how='left')\
+        .join(max_method_ncss, how='left')\
+        .reset_index()\
+        .rename({'File': 'filename'}, axis='columns')
 
 
-if not os.path.isdir(DIR_TO_CREATE):
-    os.makedirs(DIR_TO_CREATE)
+def main() -> None:
+    args = create_parser().parse_args()
+    dir_to_analyze = Path(args.dir or './target/01')
+    csv_files = run_pmd(dir_to_analyze)
+    frames = read_pmd_frames(csv_files)
+    print(f'we have {len(csv_files)} analysis targets, {len(frames)} datasets')
+    metrics = build_metrics(frames)
 
-metrics.to_csv(DIR_TO_CREATE + '/' + 'pmd_metrics.csv', sep=';', index=False)
+    if not os.path.isdir(DIR_TO_CREATE):
+        os.makedirs(DIR_TO_CREATE)
+
+    metrics.to_csv(DIR_TO_CREATE + '/' + 'pmd_metrics.csv', sep=';', index=False)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/03-calculate-metrics.py
+++ b/scripts/03-calculate-metrics.py
@@ -11,6 +11,7 @@ DIR_TO_CREATE = 'target/03'
 
 
 def create_parser() -> argparse.ArgumentParser:
+    """Build the CLI parser for the metrics calculation script."""
     parser = argparse.ArgumentParser(description='Calculate metrics for Java files')
     parser.add_argument(
         '--dir',
@@ -21,6 +22,7 @@ def create_parser() -> argparse.ArgumentParser:
 
 
 def collect_analysis_targets(dir_to_analyze: Path) -> list[Path]:
+    """Collect top-level directories and Java files that should be analyzed."""
     return [
         path for path in sorted(dir_to_analyze.iterdir(), key=lambda path: path.name)
         if path.is_dir() or path.suffix == '.java'
@@ -28,12 +30,14 @@ def collect_analysis_targets(dir_to_analyze: Path) -> list[Path]:
 
 
 def csv_filename_for_path(path: Path) -> str:
+    """Return a temporary PMD report filename for the given analysis target."""
     if path.is_dir():
         return f'./_tmp/{path.name}_pmd_out.csv'
     return f'./_tmp/file_{path.stem}_pmd_out.csv'
 
 
 def run_pmd(dir_to_analyze: Path) -> list[str]:
+    """Run PMD for each collected target and return generated CSV paths."""
     csv_files = []
     for path_to_analyze in collect_analysis_targets(dir_to_analyze):
         print(f'Start metrics calculation for path {path_to_analyze.name}')
@@ -50,6 +54,7 @@ def run_pmd(dir_to_analyze: Path) -> list[str]:
 
 
 def read_pmd_frames(csv_files: list[str]) -> list[pd.DataFrame]:
+    """Read all successfully generated PMD CSV files into data frames."""
     frames = []
     for csv_file in csv_files:
         try:
@@ -61,6 +66,7 @@ def read_pmd_frames(csv_files: list[str]) -> list[pd.DataFrame]:
 
 
 def build_metrics(frames: list[pd.DataFrame]) -> pd.DataFrame:
+    """Aggregate raw PMD reports into the final metrics table."""
     df = pd.concat(frames)
     df = df[df.Problem != -555]
     df.to_csv('./_tmp/pmd_out.csv')
@@ -137,6 +143,7 @@ def build_metrics(frames: list[pd.DataFrame]) -> pd.DataFrame:
 
 
 def main() -> None:
+    """Execute the metrics calculation pipeline from CLI arguments."""
     args = create_parser().parse_args()
     dir_to_analyze = Path(args.dir or './target/01')
     csv_files = run_pmd(dir_to_analyze)

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -26,7 +26,7 @@ filter:
 
 # Here we go through the list of all Java classes in target/02,
 # and calculate a few metrics per each of them. The result of
-# calculation we store into target/03-metrics.csv
+# calculation we store into target/03/pmd_metrics.csv
 
 ./_tmp/pmd-bin/bin/run.sh:
 	mkdir -p _tmp

--- a/test/scripts/test_calculate_metrics.py
+++ b/test/scripts/test_calculate_metrics.py
@@ -1,0 +1,34 @@
+import importlib.util
+from pathlib import Path
+
+
+def load_calculate_metrics_module():
+    script_path = Path(__file__).resolve().parents[2] / 'scripts' / '03-calculate-metrics.py'
+    spec = importlib.util.spec_from_file_location('calculate_metrics', script_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_collect_analysis_targets_includes_top_level_java_files(tmp_path):
+    module = load_calculate_metrics_module()
+    root_java = tmp_path / 'TopLevel.java'
+    root_java.write_text('class TopLevel {}', encoding='utf-8')
+
+    targets = module.collect_analysis_targets(tmp_path)
+
+    assert targets == [root_java]
+
+
+def test_collect_analysis_targets_keeps_directories_and_root_java_files(tmp_path):
+    module = load_calculate_metrics_module()
+    nested_dir = tmp_path / 'project'
+    nested_dir.mkdir()
+    root_java = tmp_path / 'TopLevel.java'
+    root_java.write_text('class TopLevel {}', encoding='utf-8')
+    (tmp_path / 'README.md').write_text('ignore me', encoding='utf-8')
+
+    targets = module.collect_analysis_targets(tmp_path)
+
+    assert [path.name for path in targets] == ['TopLevel.java', 'project']

--- a/test/scripts/test_calculate_metrics.py
+++ b/test/scripts/test_calculate_metrics.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+# SPDX-License-Identifier: MIT
 import importlib.util
 from pathlib import Path
 
@@ -5,8 +7,11 @@ from pathlib import Path
 def load_calculate_metrics_module():
     script_path = Path(__file__).resolve().parents[2] / 'scripts' / '03-calculate-metrics.py'
     spec = importlib.util.spec_from_file_location('calculate_metrics', script_path)
+    if spec is None:
+        raise RuntimeError(f'Failed to load module spec from {script_path}')
+    if spec.loader is None:
+        raise RuntimeError(f'Failed to load module loader from {script_path}')
     module = importlib.util.module_from_spec(spec)
-    assert spec.loader is not None
     spec.loader.exec_module(module)
     return module
 

--- a/test/scripts/test_calculate_metrics.py
+++ b/test/scripts/test_calculate_metrics.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 
 def load_calculate_metrics_module():
+    """Load the metrics script as a Python module for direct testing."""
     script_path = Path(__file__).resolve().parents[2] / 'scripts' / '03-calculate-metrics.py'
     spec = importlib.util.spec_from_file_location('calculate_metrics', script_path)
     if spec is None:
@@ -17,6 +18,7 @@ def load_calculate_metrics_module():
 
 
 def test_collect_analysis_targets_includes_top_level_java_files(tmp_path):
+    """Top-level Java files should be included in analysis targets."""
     module = load_calculate_metrics_module()
     root_java = tmp_path / 'TopLevel.java'
     root_java.write_text('class TopLevel {}', encoding='utf-8')
@@ -27,6 +29,7 @@ def test_collect_analysis_targets_includes_top_level_java_files(tmp_path):
 
 
 def test_collect_analysis_targets_keeps_directories_and_root_java_files(tmp_path):
+    """Directories and root-level Java files should both be analyzed."""
     module = load_calculate_metrics_module()
     nested_dir = tmp_path / 'project'
     nested_dir.mkdir()


### PR DESCRIPTION
## Summary
- include root-level `.java` files in `scripts/03-calculate-metrics.py` instead of only scanning immediate subdirectories
- keep directory processing unchanged so nested project trees are still analyzed once per top-level directory
- add regression tests for root-only and mixed root-file-plus-directory inputs

## Verification
- `python3 -m pytest test/scripts/test_calculate_metrics.py -q`
- `python3 -m flake8 --max-line-length=120 scripts/03-calculate-metrics.py test/scripts/test_calculate_metrics.py`
- `python3 -m pylint scripts/03-calculate-metrics.py test/scripts/test_calculate_metrics.py`

Closes #336

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Metrics tool now supports analyzing both directories and individual `*.java` files, producing aggregated output at `target/03/pmd_metrics.csv`.

* **Refactor**
  * Metrics generation was reorganized into a reusable workflow with dedicated steps for target discovery, per-target CSV generation, frame loading, and final metric aggregation.

* **Bug Fixes**
  * Unreadable/invalid intermediate CSVs are skipped, and invalid metric rows are filtered out before aggregation.

* **Tests**
  * Added coverage for target discovery behavior across nested directories vs top-level Java files.

* **Documentation**
  * Updated Makefile guidance to reflect the new output path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->