### PR TITLE
fix: skip ASSERT_STATEMENT in ClassicGetter body check #1188

### DIFF
--- a/aibolit/patterns/classic_getter/classic_getter.py
+++ b/aibolit/patterns/classic_getter/classic_getter.py
@@ -17,6 +17,9 @@ class ClassicGetter:
         (in self.suitable_nodes) or not.
         """
         for node in check_getter_body:
+            if node.node_type == ASTNodeType.ASSERT_STATEMENT:
+                continue
+
             if not hasattr(node, 'expression'):
                 return False
 

--- a/test/patterns/classic_getter/test_classic_getter.py
+++ b/test/patterns/classic_getter/test_classic_getter.py
@@ -56,6 +56,21 @@ def test_getter_using_this_reference() -> None:
     assert _offending_lines(content) == [3]
 
 
+def test_getter_with_leading_assert() -> None:
+    content = dedent(
+        '''\
+        class Dummy {
+            private int value;
+            public int getValue() {
+                assert this.value >= 0;
+                return this.value;
+            }
+        }
+        '''
+    ).strip()
+    assert _offending_lines(content) == [3]
+
+
 def test_getSomething_method_that_does_not_return() -> None:
     content = dedent(
         '''\


### PR DESCRIPTION
The `ClassicGetter` pattern's `_check_body_nodes` walks the method body and bails on the first node that lacks an `expression` attribute, which catches `AssertStatement` nodes and silently drops getters that begin with an `assert`. That contradicts the class docstring (`Return statement is the only statement, excepting asserts.`) and the published example in `PATTERNS.md` lines 100-108.

This change skips `ASTNodeType.ASSERT_STATEMENT` nodes at the top of the loop in `aibolit/patterns/classic_getter/classic_getter.py` before the `expression`/`_is_return` checks, so a leading `assert` no longer disqualifies a method. A regression test `test_getter_with_leading_assert` is added to `test/patterns/classic_getter/test_classic_getter.py`, modeled on the existing `test_getter_using_this_reference` helper.

Local checks on the changed files: `pytest test/patterns/classic_getter/` 7 passed; `pytest test/patterns/` 281 passed, 7 skipped; `flake8`, `pylint` (10.00/10), `mypy`, and `bandit -lll` all clean.

Closes #1188

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed validation of getter methods that contain assertion statements, now properly allowing assertions alongside getter logic.

* **Tests**
  * Added test coverage for getter methods with leading assertion statements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->