### PR TITLE
fix: version() prints aibolit name instead of literal %(prog)s

### DIFF
--- a/aibolit/__main__.py
+++ b/aibolit/__main__.py
@@ -863,15 +863,9 @@ def format_converter_for_pattern(results, sorted_by=None):
 
 def version():
     """
-    Parses arguments and shows current version of program.
+    Shows current version of program.
     """
-
-    parser = argparse.ArgumentParser(
-        description='Show version')
-    parser.add_argument(
-        '--version',
-    )
-    print(f'%(prog)s {__version__}')
+    print(f'aibolit {__version__}')
 
 
 def run_thread(files, args):


### PR DESCRIPTION
Fixes #1207

## Problem
The `version()` function used `print(f'%(prog)s {__version__}')`. The `%(prog)s` token is only interpolated by argparse (when passed as the `version=` argument), not by Python's f-string formatter — so it printed literally as `%(prog)s 0.0.0` instead of `aibolit 0.0.0`.

The surrounding `argparse.ArgumentParser` was also dead code: it had no `action='version'`, no `version=` argument, and never called `parse_args()`.

## Fix
- Removed the dead argparse code
- Replaced the print with `print(f'aibolit {__version__}')` so the output is correct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the version command output display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->