### PR TITLE
Ignore getClass() chains in P10

### DIFF
--- a/aibolit/patterns/method_chaining/method_chaining.py
+++ b/aibolit/patterns/method_chaining/method_chaining.py
@@ -16,6 +16,8 @@ class MethodChainFind:
         for node in ast.proxy_nodes(ASTNodeType.CLASS_CREATOR,
                                     ASTNodeType.METHOD_INVOCATION,
                                     ASTNodeType.THIS):
+            if self._is_jdk_class_chain(node):
+                continue
             selectors_qty = self._get_selectors_qty(node)
             if selectors_qty > MethodChainFind._allowed_number_of_selectord[node.node_type]:
                 lines.append(node.line)
@@ -27,6 +29,11 @@ class MethodChainFind:
             return 0
 
         return len(node.selectors)
+
+    def _is_jdk_class_chain(self, node: ASTNode) -> bool:
+        return node.node_type == ASTNodeType.METHOD_INVOCATION and node.member == 'getClass' and (
+            self._get_selectors_qty(node) > 0
+        )
 
     _allowed_number_of_selectord = {
         # found node already is a method invocation, so no further invocations are allowed

--- a/test/patterns/method_chaining/test_method_chaining.py
+++ b/test/patterns/method_chaining/test_method_chaining.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from aibolit.patterns.method_chaining.method_chaining import MethodChainFind
 from aibolit.ast_framework import AST
-from aibolit.utils.ast_builder import build_ast
+from aibolit.utils.ast_builder import build_ast, build_ast_from_string
 
 
 class MethodChainTestCase(TestCase):
@@ -120,3 +120,19 @@ class MethodChainTestCase(TestCase):
         pattern = MethodChainFind()
         lines = pattern.value(ast)
         self.assertGreater(len(lines), 300)
+
+    def test_jdk_class_chain_is_ignored(self):
+        ast = AST.build_from_javalang(
+            build_ast_from_string(
+                '''
+                class Example {
+                    String canonicalName(Object foo) {
+                        return foo.getClass().getCanonicalName();
+                    }
+                }
+                '''
+            )
+        )
+        pattern = MethodChainFind()
+        lines = pattern.value(ast)
+        self.assertEqual(lines, [])


### PR DESCRIPTION
## Summary
- ignore method-chain findings that start from `getClass()` so reflection/JDK `Class` lookups are not reported as P10
- add a regression test for `foo.getClass().getCanonicalName()`

## Problem
`MethodChainFind` currently reports `foo.getClass().getCanonicalName()` as a method chain.
This is a false positive for JDK/reflection-style `Class` lookups, where the chain is a normal way to access metadata.

## Fix
Skip `METHOD_INVOCATION` nodes whose root call is `getClass()` and which continue through selectors.

## Verification
- `python3 -B -m unittest test.patterns.method_chaining.test_method_chaining`
- `python3 -B -m flake8 --max-line-length=120 aibolit/patterns/method_chaining/method_chaining.py test/patterns/method_chaining/test_method_chaining.py`
- `TMPDIR=/Users/iliaprokofev/.tmp-codex-aibolit python3 -B -m pylint aibolit/patterns/method_chaining/method_chaining.py test/patterns/method_chaining/test_method_chaining.py`

Closes #370

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved method-chain detection to ignore a specific standard library-style `getClass()` chain, reducing false positives in analysis results.
  * Added coverage for this case to ensure chained calls like `getCanonicalName()` are handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->