### PR TITLE
Ignore lambda casts in P5

### DIFF
--- a/aibolit/patterns/force_type_casting_finder/force_type_casting_finder.py
+++ b/aibolit/patterns/force_type_casting_finder/force_type_casting_finder.py
@@ -8,4 +8,8 @@ from aibolit.ast_framework import AST, ASTNodeType
 
 class ForceTypeCastingFinder:
     def value(self, ast: AST) -> List[int]:
-        return [cast.expression.line for cast in ast.proxy_nodes(ASTNodeType.CAST)]
+        return [
+            cast.expression.line
+            for cast in ast.proxy_nodes(ASTNodeType.CAST)
+            if cast.expression.node_type != ASTNodeType.LAMBDA_EXPRESSION
+        ]

--- a/aibolit/patterns/force_type_casting_finder/force_type_casting_finder.py
+++ b/aibolit/patterns/force_type_casting_finder/force_type_casting_finder.py
@@ -7,7 +7,10 @@ from aibolit.ast_framework import AST, ASTNodeType
 
 
 class ForceTypeCastingFinder:
+    """Find explicit type-cast expressions that should be reported as P5."""
+
     def value(self, ast: AST) -> List[int]:
+        """Return source lines of reported cast expressions."""
         return [
             cast.expression.line
             for cast in ast.proxy_nodes(ASTNodeType.CAST)

--- a/test/patterns/force_type_casting_finder/test_force_type_casting_finder.py
+++ b/test/patterns/force_type_casting_finder/test_force_type_casting_finder.py
@@ -6,7 +6,7 @@ from unittest import TestCase
 
 from aibolit.patterns.force_type_casting_finder import force_type_casting_finder
 from aibolit.ast_framework import AST
-from aibolit.utils.ast_builder import build_ast
+from aibolit.utils.ast_builder import build_ast, build_ast_from_string
 
 
 class ForceTypeCastingFinderTestCase(TestCase):
@@ -28,5 +28,24 @@ class ForceTypeCastingFinderTestCase(TestCase):
         pattern = force_type_casting_finder.ForceTypeCastingFinder()
         path = os.path.dirname(os.path.realpath(__file__)) + '/3.java'
         ast = AST.build_from_javalang(build_ast(path))
+        lines = pattern.value(ast)
+        self.assertEqual(lines, [])
+
+    def test_lambda_cast_is_ignored(self):
+        pattern = force_type_casting_finder.ForceTypeCastingFinder()
+        ast = AST.build_from_javalang(build_ast_from_string(
+            '''
+            class Example {
+                public void mapsToSameObjects() {
+                    final Iterable<Scalar<Integer>> list = new Solid<>(
+                        new org.cactoos.list.Mapped<>(
+                            i -> (Scalar<Integer>) () -> i,
+                            new IterableOf<>(1, -1, 0, 1)
+                        )
+                    );
+                }
+            }
+            '''
+        ))
         lines = pattern.value(ast)
         self.assertEqual(lines, [])

--- a/test/patterns/force_type_casting_finder/test_force_type_casting_finder.py
+++ b/test/patterns/force_type_casting_finder/test_force_type_casting_finder.py
@@ -11,6 +11,7 @@ from aibolit.utils.ast_builder import build_ast, build_ast_from_string
 
 class ForceTypeCastingFinderTestCase(TestCase):
     def test_simple(self):
+        """Regular casts should still be reported."""
         pattern = force_type_casting_finder.ForceTypeCastingFinder()
         path = os.path.dirname(os.path.realpath(__file__)) + '/1.java'
         ast = AST.build_from_javalang(build_ast(path))
@@ -18,6 +19,7 @@ class ForceTypeCastingFinderTestCase(TestCase):
         self.assertEqual(lines, [8])
 
     def test_several_casts(self):
+        """Multiple ordinary casts should all be reported."""
         pattern = force_type_casting_finder.ForceTypeCastingFinder()
         path = os.path.dirname(os.path.realpath(__file__)) + '/2.java'
         ast = AST.build_from_javalang(build_ast(path))
@@ -25,6 +27,7 @@ class ForceTypeCastingFinderTestCase(TestCase):
         self.assertEqual(lines, [8, 14, 20])
 
     def test_zero_lines(self):
+        """Files without casts should produce no findings."""
         pattern = force_type_casting_finder.ForceTypeCastingFinder()
         path = os.path.dirname(os.path.realpath(__file__)) + '/3.java'
         ast = AST.build_from_javalang(build_ast(path))
@@ -32,6 +35,7 @@ class ForceTypeCastingFinderTestCase(TestCase):
         self.assertEqual(lines, [])
 
     def test_lambda_cast_is_ignored(self):
+        """Casts applied to lambda expressions should not be reported."""
         pattern = force_type_casting_finder.ForceTypeCastingFinder()
         ast = AST.build_from_javalang(build_ast_from_string(
             '''


### PR DESCRIPTION
## Summary
- ignore P5 findings for casts whose expression is a lambda
- add regression coverage for the cactoos-style lambda cast reported in the issue

## Problem
`ForceTypeCastingFinder` currently reports casts like `(Scalar<Integer>) () -> i` as force type casting. In this case the cast applies to a lambda expression and is used to adapt it to the target functional type, which matches the false positive reported in #343.

## Fix
Skip `CAST` nodes whose expression is a `LAMBDA_EXPRESSION`.

## Verification
- `python3 -B -m unittest test.patterns.force_type_casting_finder.test_force_type_casting_finder`
- `python3 -B -m flake8 --max-line-length=120 aibolit/patterns/force_type_casting_finder/force_type_casting_finder.py test/patterns/force_type_casting_finder/test_force_type_casting_finder.py`
- `TMPDIR=/Users/iliaprokofev/.tmp-codex-aibolit python3 -B -m pylint aibolit/patterns/force_type_casting_finder/force_type_casting_finder.py test/patterns/force_type_casting_finder/test_force_type_casting_finder.py`

Closes #343

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type-cast detection so casts used with lambda expressions are no longer reported.
  * Reduced false positives in pattern results while keeping existing cast detection behavior intact.
* **Tests**
  * Added coverage for lambda-based casts to confirm they are ignored by the matcher.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->