### PR TITLE
#811: Fix XML pattern count for nested recommend results

### DIFF
--- a/aibolit/__main__.py
+++ b/aibolit/__main__.py
@@ -607,7 +607,10 @@ def create_xml_tree(results, full_report, cmd, exit_code):
         file = etree.SubElement(files, 'file')
         score_for_file = _process_file_result(file, result_for_file)
         if score_for_file is not None:
-            total_patterns += len(result_for_file['results'])
+            file_results = result_for_file['results']
+            if file_results and all(isinstance(item, list) for item in file_results):
+                file_results = flatten(file_results)
+            total_patterns += len(file_results)
             importances_for_all_classes.append(score_for_file)
 
     patterns_number_tag.text = str(total_patterns)

--- a/test/recommend/test_recommend_pipeline.py
+++ b/test/recommend/test_recommend_pipeline.py
@@ -159,7 +159,10 @@ class TestRecommendPipeline(TestCase):
     def test_xml(self):
         mock_input = self.__create_mock_input()
         mock_cmd = self.__create_mock_cmd()
-        create_xml_tree(mock_input, full_report=True, cmd=mock_cmd, exit_code=2)
+        root = create_xml_tree(mock_input, full_report=True, cmd=mock_cmd, exit_code=2)
+
+        self.assertEqual(root.findtext('./header/patterns'), '5')
+        self.assertEqual(len(root.findall('./files/file/patterns/pattern')), 5)
 
     def test_count_value_keeps_original_exception_context(self):
         value_dict = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pattern counting in generated XML so totals are accurate even when results are returned in nested lists.
  * Improved XML output consistency by ensuring file-level pattern counts match the actual number of patterns reported.
* **Tests**
  * Updated automated coverage to verify the returned XML tree and its reported pattern counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->