### PR TITLE
Extract NPath report parser

### DIFF
--- a/aibolit/metrics/npath/main.py
+++ b/aibolit/metrics/npath/main.py
@@ -67,7 +67,6 @@ class NPathMetric():
     def parse_report(content: str, root: str):
         """Parse PMD XML output into the metric result structure."""
         data: list[dict[str, int | str]] = []
-        errors: list[str] = []
         soup = BeautifulSoup(content, features='xml')
         for file_tag in soup.find_all('file'):
             out = file_tag.violation.get_text(strip=True) if file_tag.violation else ''
@@ -81,9 +80,9 @@ class NPathMetric():
             data.append({'file': name, 'complexity': complexity})
         error_tags = soup.find_all('error')
         for error in error_tags:
-            NPathMetric._relative_source_name(error['filename'], root)
-            raise Exception(error['msg'])
-        return {'data': data, 'errors': errors}
+            name = NPathMetric._relative_source_name(error['filename'], root)
+            raise Exception(f'{name}: {error["msg"]}')
+        return {'data': data, 'errors': []}
 
     @staticmethod
     def _relative_source_name(path: str, root: str) -> str:

--- a/aibolit/metrics/npath/main.py
+++ b/aibolit/metrics/npath/main.py
@@ -49,38 +49,46 @@ class NPathMetric():
                                stdout=subprocess.DEVNULL,
                                stderr=subprocess.DEVNULL)
             if os.path.isfile(f'{root}/target/pmd.xml'):
-                res = self.__parseFile(root)
-                return res
+                return self._parse_report_file(f'{root}/target/pmd.xml', root)
             raise Exception(' '.join(['File', self.input, 'analyze failed']))
         finally:
             shutil.rmtree(root)
 
-    def __parseFile(self, root):
+    @staticmethod
+    def _parse_report_file(report_path: str, root: str):
+        """Read a PMD XML report from disk and parse its NPath results."""
+        with open(report_path, 'r', encoding='utf-8') as file:
+            return NPathMetric.parse_report(file.read(), root)
+
+    @staticmethod
+    def parse_report(content: str, root: str):
+        """Parse PMD XML output into the metric result structure."""
         result = {'data': [], 'errors': []}
-        content = []
-        with open(f'{root}/target/pmd.xml', 'r', encoding='utf-8') as file:
-            content = file.read()
-            soup = BeautifulSoup(content, features='xml')
-            files = soup.find_all('file')
-            for file in files:
-                out = file.violation.string
-                name = file['name']
-                pos1 = name.find(f'{root}/src/main/java/')
-                pos1 = pos1 + len(f'{root}/src/main/java/')
-                name = name[pos1:]
-                s = 'NPath complexity of '
-                pos1 = out.find(s)
-                pos1 = pos1 + len(s)
-                complexity = int(out[pos1:])
-                result['data'].append({'file': name, 'complexity': complexity})
-            errors = soup.find_all('error')
-            for error in errors:
-                name = error['filename']
-                pos1 = name.find(f'{root}/src/main/java/')
-                pos1 = pos1 + len(f'{root}/src/main/java/')
-                name = name[pos1:]
-                raise Exception(error['msg'])
+        soup = BeautifulSoup(content, features='xml')
+        files = soup.find_all('file')
+        for file in files:
+            out = file.violation.string
+            name = NPathMetric._relative_source_name(file['name'], root)
+            s = 'NPath complexity of '
+            pos1 = out.find(s)
+            pos1 = pos1 + len(s)
+            complexity = int(out[pos1:])
+            result['data'].append({'file': name, 'complexity': complexity})
+        errors = soup.find_all('error')
+        for error in errors:
+            NPathMetric._relative_source_name(error['filename'], root)
+            raise Exception(error['msg'])
         return result
+
+    @staticmethod
+    def _relative_source_name(path: str, root: str) -> str:
+        """Trim the generated PMD source prefix from a reported file path."""
+        source_prefix = f'{root}/src/main/java/'
+        pos1 = path.find(source_prefix)
+        if pos1 == -1:
+            return path
+        pos1 = pos1 + len(source_prefix)
+        return path[pos1:]
 
 
 class MvnFreeNPathMetric:

--- a/aibolit/metrics/npath/main.py
+++ b/aibolit/metrics/npath/main.py
@@ -3,6 +3,7 @@
 
 import math
 import os
+import re
 import shutil
 import subprocess
 import tempfile
@@ -27,6 +28,7 @@ class NPathMetric():
 
         if len(self.input) == 0:
             raise ValueError('Empty file for analysis')
+        root = None
         try:
             root = os.path.join(tempfile.gettempdir(), uuid.uuid4().hex)
             dirName = os.path.join(root, 'src/main/java')
@@ -52,7 +54,8 @@ class NPathMetric():
                 return self._parse_report_file(f'{root}/target/pmd.xml', root)
             raise Exception(' '.join(['File', self.input, 'analyze failed']))
         finally:
-            shutil.rmtree(root)
+            if root and os.path.isdir(root):
+                shutil.rmtree(root)
 
     @staticmethod
     def _parse_report_file(report_path: str, root: str):
@@ -65,14 +68,15 @@ class NPathMetric():
         """Parse PMD XML output into the metric result structure."""
         result = {'data': [], 'errors': []}
         soup = BeautifulSoup(content, features='xml')
-        files = soup.find_all('file')
-        for file in files:
-            out = file.violation.string
-            name = NPathMetric._relative_source_name(file['name'], root)
-            s = 'NPath complexity of '
-            pos1 = out.find(s)
-            pos1 = pos1 + len(s)
-            complexity = int(out[pos1:])
+        for file_tag in soup.find_all('file'):
+            out = file_tag.violation.get_text(strip=True) if file_tag.violation else ''
+            match = re.search(r'NPath complexity of\s+(\d+)', out)
+            if not match:
+                raise ValueError(
+                    f'Unexpected PMD violation format for {file_tag["name"]}: {out}'
+                )
+            name = NPathMetric._relative_source_name(file_tag['name'], root)
+            complexity = int(match.group(1))
             result['data'].append({'file': name, 'complexity': complexity})
         errors = soup.find_all('error')
         for error in errors:
@@ -83,12 +87,15 @@ class NPathMetric():
     @staticmethod
     def _relative_source_name(path: str, root: str) -> str:
         """Trim the generated PMD source prefix from a reported file path."""
-        source_prefix = f'{root}/src/main/java/'
-        pos1 = path.find(source_prefix)
+        normalized_path = os.path.normpath(path).replace('\\', '/')
+        normalized_prefix = os.path.normpath(
+            os.path.join(root, 'src', 'main', 'java')
+        ).replace('\\', '/') + '/'
+        pos1 = normalized_path.find(normalized_prefix)
         if pos1 == -1:
             return path
-        pos1 = pos1 + len(source_prefix)
-        return path[pos1:]
+        pos1 = pos1 + len(normalized_prefix)
+        return normalized_path[pos1:]
 
 
 class MvnFreeNPathMetric:

--- a/aibolit/metrics/npath/main.py
+++ b/aibolit/metrics/npath/main.py
@@ -66,7 +66,8 @@ class NPathMetric():
     @staticmethod
     def parse_report(content: str, root: str):
         """Parse PMD XML output into the metric result structure."""
-        result = {'data': [], 'errors': []}
+        data: list[dict[str, int | str]] = []
+        errors: list[str] = []
         soup = BeautifulSoup(content, features='xml')
         for file_tag in soup.find_all('file'):
             out = file_tag.violation.get_text(strip=True) if file_tag.violation else ''
@@ -77,12 +78,12 @@ class NPathMetric():
                 )
             name = NPathMetric._relative_source_name(file_tag['name'], root)
             complexity = int(match.group(1))
-            result['data'].append({'file': name, 'complexity': complexity})
-        errors = soup.find_all('error')
-        for error in errors:
+            data.append({'file': name, 'complexity': complexity})
+        error_tags = soup.find_all('error')
+        for error in error_tags:
             NPathMetric._relative_source_name(error['filename'], root)
             raise Exception(error['msg'])
-        return result
+        return {'data': data, 'errors': errors}
 
     @staticmethod
     def _relative_source_name(path: str, root: str) -> str:

--- a/test/metrics/npath/test_report_parsing.py
+++ b/test/metrics/npath/test_report_parsing.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+# SPDX-License-Identifier: MIT
+
+import pytest
+
+from aibolit.metrics.npath.main import NPathMetric
+
+
+def test_parse_report_reads_complexity_from_xml():
+    """PMD XML content should be parsed without touching the filesystem."""
+    result = NPathMetric.parse_report(
+        '''
+        <pmd>
+          <file name="/tmp/npath/src/main/java/test/metrics/npath/Foo.java">
+            <violation>NPath complexity of 200</violation>
+          </file>
+        </pmd>
+        ''',
+        '/tmp/npath',
+    )
+
+    assert result == {
+        'data': [{'file': 'test/metrics/npath/Foo.java', 'complexity': 200}],
+        'errors': [],
+    }
+
+
+def test_parse_report_raises_pmd_error():
+    """PMD error entries should still surface as exceptions."""
+    with pytest.raises(Exception, match='PMDException'):
+        NPathMetric.parse_report(
+            '''
+            <pmd>
+              <error filename="/tmp/npath/src/main/java/test/metrics/npath/ooo.java"
+                     msg="PMDException" />
+            </pmd>
+            ''',
+            '/tmp/npath',
+        )

--- a/test/metrics/npath/test_report_parsing.py
+++ b/test/metrics/npath/test_report_parsing.py
@@ -3,6 +3,7 @@
 
 import pytest
 
+from aibolit.metrics.npath import main as npath_main
 from aibolit.metrics.npath.main import NPathMetric
 
 
@@ -37,3 +38,50 @@ def test_parse_report_raises_pmd_error():
             ''',
             '/tmp/npath',
         )
+
+
+def test_parse_report_raises_on_malformed_violation():
+    """Unexpected violation text should fail with a descriptive parser error."""
+    with pytest.raises(ValueError, match='Unexpected PMD violation format'):
+        NPathMetric.parse_report(
+            '''
+            <pmd>
+              <file name="/tmp/npath/src/main/java/test/metrics/npath/Foo.java">
+                <violation>unexpected</violation>
+              </file>
+            </pmd>
+            ''',
+            '/tmp/npath',
+        )
+
+
+def test_parse_report_normalizes_windows_source_paths():
+    """Windows-style PMD paths should still be trimmed to source-relative names."""
+    result = NPathMetric.parse_report(
+        '''
+        <pmd>
+          <file name="C:\\tmp\\npath\\src\\main\\java\\test\\metrics\\npath\\Foo.java">
+            <violation>NPath complexity of 200</violation>
+          </file>
+        </pmd>
+        ''',
+        'C:\\tmp\\npath',
+    )
+
+    assert result == {
+        'data': [{'file': 'test/metrics/npath/Foo.java', 'complexity': 200}],
+        'errors': [],
+    }
+
+
+def test_value_preserves_root_initialization_error(monkeypatch):
+    """Temporary-root setup errors should not be masked by cleanup."""
+    metric = NPathMetric('Foo.java')
+
+    def fail_gettempdir():
+        raise RuntimeError('temp root failed')
+
+    monkeypatch.setattr(npath_main.tempfile, 'gettempdir', fail_gettempdir)
+
+    with pytest.raises(RuntimeError, match='temp root failed'):
+        metric.value()

--- a/test/metrics/npath/test_report_parsing.py
+++ b/test/metrics/npath/test_report_parsing.py
@@ -27,8 +27,8 @@ def test_parse_report_reads_complexity_from_xml():
 
 
 def test_parse_report_raises_pmd_error():
-    """PMD error entries should still surface as exceptions."""
-    with pytest.raises(Exception, match='PMDException'):
+    """PMD error entries should surface with source-relative filenames."""
+    with pytest.raises(Exception, match='test/metrics/npath/ooo.java: PMDException'):
         NPathMetric.parse_report(
             '''
             <pmd>


### PR DESCRIPTION
## Summary
- extract NPath PMD XML parsing into standalone helpers that accept report content directly
- keep the filesystem/Maven part as a thin imperative shell around report generation
- add parser-focused unit tests that validate complexity extraction and PMD error propagation without invoking `mvn`

## Problem
`NPathMetric` still mixes process orchestration and PMD output analysis: the parser is only reachable through a private method that reads `target/pmd.xml` from a generated root directory. That makes the XML-analysis path awkward to test in isolation.

## Fix
Split the parsing path into `_parse_report_file()` and `parse_report()`. `value()` still drives Maven and the temporary project layout, but the report-analysis logic now accepts XML content directly, which lets tests target parsing behavior without filesystem setup or subprocess execution.

## Verification
- `TMPDIR=/Users/iliaprokofev/.tmp-codex-aibolit python3 -B -m pytest test/metrics/npath/test_report_parsing.py -q`
- `python3 -B -m flake8 --max-line-length=120 aibolit/metrics/npath/main.py test/metrics/npath/test_report_parsing.py`
- `TMPDIR=/Users/iliaprokofev/.tmp-codex-aibolit python3 -B -m pylint aibolit/metrics/npath/main.py test/metrics/npath/test_report_parsing.py`

## Notes
- The existing `test/metrics/npath/test_all_types.py` cases still require `mvn` in the current tree, so they were not re-run in this environment.

Closes #796

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved NPath metric report parsing by splitting report loading, XML parsing, and source-path normalization into clearer reusable steps.
  * Added regex-based extraction of NPath complexity values from PMD output.
* **Bug Fixes**
  * Safer temporary directory cleanup to avoid unintended removal in edge cases.
  * Ensures exceptions during temporary-root setup aren’t masked by cleanup logic.
* **Tests**
  * Expanded coverage for parsing PMD XML from an in-memory string.
  * Added tests for `<error>` handling, malformed violation text, and Windows-style path normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->