### PR TITLE
Deduplicate class-level patterns after decomposition

### DIFF
--- a/aibolit/__main__.py
+++ b/aibolit/__main__.py
@@ -39,6 +39,7 @@ from aibolit.ml_pipeline.ml_pipeline import train_process, collect_dataset
 from aibolit.utils.ast_builder import build_ast
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
+CLASS_LEVEL_PATTERN_CODES = frozenset({'P4', 'P7', 'P9', 'P24'})
 
 
 def list_dir(path, files):
@@ -292,6 +293,11 @@ def calculate_patterns_and_metrics_with_decomposition(
             if node.node_type == ASTNodeType.CLASS_DECLARATION
         ]
         for class_ast in classes_ast:
+            class_level_pattern_results = {
+                pattern_info['code']: pattern_info['make']().value(class_ast)
+                for pattern_info in patterns_info
+                if pattern_info['code'] in CLASS_LEVEL_PATTERN_CODES
+            }
             for index, component_ast in enumerate(decompose_java_class(class_ast, 'strong')):
                 result_for_component: Dict[Any, Any] = {}
                 code_lines_dict: Dict[Any, Any] = OrderedDict()
@@ -304,8 +310,13 @@ def calculate_patterns_and_metrics_with_decomposition(
                         input_params[pattern_info['code']] = 0
                         code_lines_dict['lines_' + pattern_info['code']] = []
                     else:
-                        pattern = pattern_info['make']()
-                        pattern_result = pattern.value(component_ast)
+                        if pattern_info['code'] in CLASS_LEVEL_PATTERN_CODES:
+                            pattern_result = class_level_pattern_results[pattern_info['code']]
+                            if index > 0:
+                                pattern_result = []
+                        else:
+                            pattern = pattern_info['make']()
+                            pattern_result = pattern.value(component_ast)
                         input_params[pattern_info['code']] = len(pattern_result)
                         code_lines_dict['lines_' + pattern_info['code']] = pattern_result
 

--- a/aibolit/__main__.py
+++ b/aibolit/__main__.py
@@ -304,8 +304,6 @@ def calculate_patterns_and_metrics_with_decomposition(
                 input_params = OrderedDict()  # type: ignore
 
                 for pattern_info in patterns_info:
-                    if pattern_info['code'] in config['patterns_exclude']:
-                        continue
                     if pattern_info['code'] in patterns_to_suppress:
                         input_params[pattern_info['code']] = 0
                         code_lines_dict['lines_' + pattern_info['code']] = []

--- a/aibolit/__main__.py
+++ b/aibolit/__main__.py
@@ -296,7 +296,10 @@ def calculate_patterns_and_metrics_with_decomposition(
             class_level_pattern_results = {
                 pattern_info['code']: pattern_info['make']().value(class_ast)
                 for pattern_info in patterns_info
-                if pattern_info['code'] in CLASS_LEVEL_PATTERN_CODES
+                if (
+                    pattern_info['code'] in CLASS_LEVEL_PATTERN_CODES and
+                    pattern_info['code'] not in patterns_to_suppress
+                )
             }
             for index, component_ast in enumerate(decompose_java_class(class_ast, 'strong')):
                 result_for_component: Dict[Any, Any] = {}

--- a/test/recommend/test_recommend_pipeline.py
+++ b/test/recommend/test_recommend_pipeline.py
@@ -4,7 +4,9 @@ import os
 from argparse import Namespace
 from hashlib import md5
 from pathlib import Path
-from unittest import TestCase
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+from unittest import TestCase, skip
 from unittest.mock import patch
 
 import javalang
@@ -135,6 +137,50 @@ class TestRecommendPipeline(TestCase):
         self.assertEqual(val, 0)
         val = code_lines_dict['P24']
         self.assertNotEqual(val, 0)
+
+    def test_decomposition_keeps_class_level_patterns_on_single_component(self):
+        """Class-level patterns should be counted once even after class decomposition."""
+        java_code = '''
+            package com.test;
+
+            import java.util.HashMap;
+            import java.util.Map;
+
+            public class ConfigManager {
+                private Map<String, String> data = new HashMap<>();
+                private int counter = 0;
+                private String name = "default";
+
+                public void setValue(String key, String value) { data.put(key, value); counter++; }
+                public String getValue(String key) { return data.get(key); }
+                public int getCounter() { return counter; }
+                public void incrementCounter() { counter++; }
+                public String getName() { return name; }
+                public void setName(String newName) { this.name = newName; }
+                public void reset() { data.clear(); counter = 0; name = "default"; }
+                public boolean hasKey(String key) { return data.containsKey(key); }
+                public int size() { return data.size(); }
+            }
+        '''
+        with TemporaryDirectory() as temp_dir:
+            file_path = Path(temp_dir, 'ConfigManager.java')
+            file_path.write_text(java_code, encoding='utf-8')
+            components, error = aibolit_main.calculate_patterns_and_metrics_with_decomposition(
+                str(file_path),
+                SimpleNamespace(suppress=[]),
+            )
+
+        self.assertIsNone(error)
+        self.assertGreater(len(components), 1)
+        self.assertEqual(sum(component['input_params']['P4'] for component in components), 1)
+        self.assertEqual(sum(component['input_params']['P24'] for component in components), 1)
+        self.assertEqual(len(components[0]['code_lines_dict']['lines_P4']), 1)
+        self.assertTrue(
+            all(component['code_lines_dict']['lines_P4'] == [] for component in components[1:])
+        )
+        self.assertTrue(
+            all(component['code_lines_dict']['lines_P24'] == [] for component in components[1:])
+        )
 
     def test_list_dir_no_java_files(self):
         found_files = []

--- a/test/recommend/test_recommend_pipeline.py
+++ b/test/recommend/test_recommend_pipeline.py
@@ -6,7 +6,7 @@ from hashlib import md5
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from types import SimpleNamespace
-from unittest import TestCase, skip
+from unittest import TestCase
 from unittest.mock import patch
 
 import javalang
@@ -146,7 +146,7 @@ class TestRecommendPipeline(TestCase):
             import java.util.HashMap;
             import java.util.Map;
 
-            public class ConfigManager {
+            public class ConfigManager implements Runnable, AutoCloseable {
                 private Map<String, String> data = new HashMap<>();
                 private int counter = 0;
                 private String name = "default";
@@ -160,6 +160,8 @@ class TestRecommendPipeline(TestCase):
                 public void reset() { data.clear(); counter = 0; name = "default"; }
                 public boolean hasKey(String key) { return data.containsKey(key); }
                 public int size() { return data.size(); }
+                public void run() { counter++; }
+                public void close() { data.clear(); }
             }
         '''
         with TemporaryDirectory() as temp_dir:
@@ -173,13 +175,54 @@ class TestRecommendPipeline(TestCase):
         self.assertIsNone(error)
         self.assertGreater(len(components), 1)
         self.assertEqual(sum(component['input_params']['P4'] for component in components), 1)
+        self.assertEqual(sum(component['input_params']['P7'] for component in components), 1)
         self.assertEqual(sum(component['input_params']['P24'] for component in components), 1)
         self.assertEqual(len(components[0]['code_lines_dict']['lines_P4']), 1)
+        self.assertEqual(len(components[0]['code_lines_dict']['lines_P7']), 1)
+        self.assertEqual(len(components[0]['code_lines_dict']['lines_P24']), 1)
         self.assertTrue(
             all(component['code_lines_dict']['lines_P4'] == [] for component in components[1:])
         )
         self.assertTrue(
+            all(component['code_lines_dict']['lines_P7'] == [] for component in components[1:])
+        )
+        self.assertTrue(
             all(component['code_lines_dict']['lines_P24'] == [] for component in components[1:])
+        )
+
+    def test_decomposition_skips_suppressed_class_level_patterns_before_precompute(self):
+        class FailingPattern:
+            def value(self, _):
+                raise AssertionError('suppressed pattern should not be evaluated')
+
+        config = {
+            'patterns': [
+                {'name': 'Failing class-level pattern', 'code': 'P4', 'make': FailingPattern},
+            ],
+            'metrics': [],
+            'patterns_exclude': [],
+            'metrics_exclude': [],
+        }
+        java_code = '''
+            public class SuppressedPatternSample {
+                public void first() {}
+                public void second() {}
+            }
+        '''
+        with TemporaryDirectory() as temp_dir:
+            file_path = Path(temp_dir, 'SuppressedPatternSample.java')
+            file_path.write_text(java_code, encoding='utf-8')
+            with patch('aibolit.__main__.Config.get_patterns_config', return_value=config):
+                components, error = aibolit_main.calculate_patterns_and_metrics_with_decomposition(
+                    str(file_path),
+                    SimpleNamespace(suppress=['P4']),
+                )
+
+        self.assertIsNone(error)
+        self.assertGreater(len(components), 0)
+        self.assertTrue(all(component['input_params']['P4'] == 0 for component in components))
+        self.assertTrue(
+            all(component['code_lines_dict']['lines_P4'] == [] for component in components)
         )
 
     def test_list_dir_no_java_files(self):


### PR DESCRIPTION
## Summary
- count class-level patterns only once per class during decomposition
- keep component-specific patterns and metrics unchanged
- add a regression test for duplicated `P4`/`P24` findings

## Problem
`calculate_patterns_and_metrics_with_decomposition()` runs every pattern on every decomposed component. Patterns that inspect `CLASS_DECLARATION` therefore report the same class once per component, which duplicates findings and distorts ranking.

## Fix
Precompute class-level pattern results on the whole class AST and attach them only to the first decomposed component. Other components keep an empty result for those patterns.

## Verification
- `python3 -B -m pytest test/recommend/test_recommend_pipeline.py -q`
- `python3 -B -m flake8 --max-line-length=120 aibolit/__main__.py test/recommend/test_recommend_pipeline.py`

Closes #1217

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved decomposed recommendation analysis so class-level patterns are pre-filtered and evaluated only once across related components.
  * Prevented duplicate class-level matches in later components, ensuring consistent pattern counts and line details.
  * Suppressed class-level patterns are now correctly skipped during decomposed analysis without impacting other results.
* **Tests**
  * Added regression coverage confirming class-level pattern counts are reported exactly once and line details appear only for the intended component.
  * Added a test ensuring suppressed class-level patterns are not computed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->