### PR TITLE
fix: #1217 deduplicate class-level findings across decomposed components

### DIFF
--- a/aibolit/__main__.py
+++ b/aibolit/__main__.py
@@ -445,8 +445,18 @@ def _extract_patterns_ignored(tree):
 
 
 def _process_components(components, args, classes_with_patterns_ignored, patterns_ignored):
-    """Process components to create results."""
+    """Process components to create results, dropping duplicate findings.
+
+    A class is decomposed into several components, each of which still holds the
+    original class-level node. Class-level patterns (e.g. ``er_class``,
+    ``non_final_class``) therefore fire once per component, reporting the same
+    violation many times and inflating its importance (see issue #1217). We keep
+    only the first finding for every ``(pattern_code, code_lines)`` pair, so an
+    identical violation is reported once while genuinely distinct findings on
+    other lines are preserved.
+    """
     results_list = []
+    seen = set()
     for lcom_component in components:
         code_lines_dict = lcom_component.get('code_lines_dict')
         input_params = lcom_component.get('input_params')
@@ -457,8 +467,15 @@ def _process_components(components, args, classes_with_patterns_ignored, pattern
             classes_with_patterns_ignored,
             patterns_ignored
         )
-        if ranked_results:
-            results_list.append(ranked_results)
+        unique_results = []
+        for pattern_item in ranked_results:
+            key = (pattern_item['pattern_code'], tuple(pattern_item['code_lines']))
+            if key in seen:
+                continue
+            seen.add(key)
+            unique_results.append(pattern_item)
+        if unique_results:
+            results_list.append(unique_results)
     return results_list
 
 

--- a/test/recommend/decomposition/ConfigManager.java
+++ b/test/recommend/decomposition/ConfigManager.java
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+// SPDX-License-Identifier: MIT
+package com.test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ConfigManager {
+    private Map<String, String> data = new HashMap<>();
+    private int counter = 0;
+    private String name = "default";
+
+    public void setValue(String key, String value) { data.put(key, value); counter++; }
+    public String getValue(String key) { return data.get(key); }
+    public int getCounter() { return counter; }
+    public void incrementCounter() { counter++; }
+    public String getName() { return name; }
+    public void setName(String n) { this.name = n; }
+    public void reset() { data.clear(); counter = 0; name = "default"; }
+    public boolean hasKey(String key) { return data.containsKey(key); }
+    public int size() { return data.size(); }
+}

--- a/test/recommend/test_recommend_pipeline.py
+++ b/test/recommend/test_recommend_pipeline.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
 # SPDX-License-Identifier: MIT
 import os
+from argparse import Namespace
 from hashlib import md5
 from pathlib import Path
 from unittest import TestCase, skip
@@ -14,7 +15,8 @@ from aibolit.config import Config
 
 from aibolit.__main__ import list_dir, calculate_patterns_and_metrics, \
     create_xml_tree, create_text, format_converter_for_pattern, find_start_and_end_lines, \
-    find_annotation_by_node_type, add_pattern_if_ignored
+    find_annotation_by_node_type, add_pattern_if_ignored, _process_components, \
+    run_recommend_for_file
 
 
 class TestRecommendPipeline(TestCase):
@@ -355,3 +357,65 @@ class TestRecommendPipeline(TestCase):
         pattern_ignored = {'P14': [[60, 100]]}
         add_pattern_if_ignored(pattern_ignored, pattern_item, results)
         self.assertEqual(results[0]['code_lines'], pattern_item['code_lines'])
+
+    def test_process_components_deduplicates_class_level_findings(self):
+        # A class-level pattern (e.g. P4 "Prohibited class name") re-fires in
+        # every decomposed component, reporting the same line repeatedly with
+        # different importance values (issue #1217). Only one finding should
+        # survive.
+        component_findings = [
+            [{'code_lines': [6], 'pattern_code': 'P4',
+              'pattern_name': 'Prohibited class name', 'importance': 6.40}],
+            [{'code_lines': [6], 'pattern_code': 'P4',
+              'pattern_name': 'Prohibited class name', 'importance': 3.20}],
+            [{'code_lines': [6], 'pattern_code': 'P4',
+              'pattern_name': 'Prohibited class name', 'importance': 6.40}],
+        ]
+        components = [{'code_lines_dict': {}, 'input_params': {}, 'index': i}
+                      for i in range(len(component_findings))]
+        with patch('aibolit.__main__.create_results', side_effect=component_findings):
+            results = _process_components(components, args=None,
+                                          classes_with_patterns_ignored=[],
+                                          patterns_ignored={})
+        flat = [item for sublist in results for item in sublist]
+        self.assertEqual(len(flat), 1)
+        self.assertEqual(flat[0]['pattern_code'], 'P4')
+        self.assertEqual(flat[0]['code_lines'], [6])
+        self.assertEqual(flat[0]['importance'], 6.40)
+
+    def test_recommend_reports_class_level_pattern_once(self):
+        # End-to-end check for issue #1217: a class that decomposes into many
+        # components must not report the same class-level violation per
+        # component. No (pattern_code, code_lines) pair may appear twice.
+        file = Path(self.cur_file_dir, 'decomposition/ConfigManager.java')
+        args = Namespace(suppress=[], model=None, full=True)
+        result = run_recommend_for_file(str(file), args)
+
+        self.assertIsNone(result['exception'])
+        findings = [item for sublist in result['results'] for item in sublist]
+        keys = [(item['pattern_code'], tuple(item['code_lines'])) for item in findings]
+        self.assertEqual(sorted(keys), sorted(set(keys)), f'duplicate findings: {keys}')
+
+    def test_process_components_keeps_distinct_findings(self):
+        # The same pattern firing on different lines, or different patterns on
+        # the same line, are genuinely distinct and must be preserved.
+        component_findings = [
+            [{'code_lines': [10], 'pattern_code': 'P2',
+              'pattern_name': 'Assert in code', 'importance': 5.67}],
+            [{'code_lines': [20], 'pattern_code': 'P2',
+              'pattern_name': 'Assert in code', 'importance': 4.36}],
+            [{'code_lines': [10], 'pattern_code': 'P5',
+              'pattern_name': 'Force type casting', 'importance': 1.23}],
+        ]
+        components = [{'code_lines_dict': {}, 'input_params': {}, 'index': i}
+                      for i in range(len(component_findings))]
+        with patch('aibolit.__main__.create_results', side_effect=component_findings):
+            results = _process_components(components, args=None,
+                                          classes_with_patterns_ignored=[],
+                                          patterns_ignored={})
+        flat = [item for sublist in results for item in sublist]
+        self.assertEqual(len(flat), 3)
+        self.assertEqual(
+            {(item['pattern_code'], tuple(item['code_lines'])) for item in flat},
+            {('P2', (10,)), ('P2', (20,)), ('P5', (10,))},
+        )


### PR DESCRIPTION
Closes #1217.

## Problem

`aibolit recommend` decomposes every class into strongly-connected components via `decompose_java_class()`. Each component AST, however, still contains the original `CLASS_DECLARATION` node, so any class-level pattern that iterates `ast.proxy_nodes(ASTNodeType.CLASS_DECLARATION)` fires **once per component** rather than once per class.

For the `ConfigManager` example from the issue (which splits into 12 components), the single "Prohibited class name" violation is reported 12 times:

```
ConfigManager.java[6]: Prohibited class name (P4: 6.40)
ConfigManager.java[6]: Prohibited class name (P4: 6.40)
... (12 lines total, all for the same class/line)
```

This also distorts the importance score, since the same line contributes to the total multiple times with different per-component values. Affected patterns include `er_class`, `non_final_class`, `many_primary_ctors`, `implements_multi` — any pattern whose `value()` walks class-declaration nodes.

## Fix

This implements **option 1** from the issue: deduplicate findings in `_process_components` by `(pattern_code, code_lines)`. The first occurrence of each violation is kept; later identical occurrences from other components are dropped. Genuinely distinct findings (same pattern on a different line, or a different pattern on the same line) are preserved.

It is the most contained of the three suggested approaches and touches only the recommend post-processing path.

## Verification

On the issue's `ConfigManager.java`:

| | before | after |
|---|---|---|
| "Prohibited class name" reports | 12 | 1 |

## Tests

- `test_process_components_deduplicates_class_level_findings` — identical findings across components collapse to one.
- `test_process_components_keeps_distinct_findings` — distinct `(code, lines)` findings are preserved.
- `test_recommend_reports_class_level_pattern_once` — end-to-end through `run_recommend_for_file` on a fixture that splits into 12 components; asserts no duplicate `(pattern_code, code_lines)` pair. Both the unit and e2e tests fail on `master` and pass with this change.

`flake8`, `ruff`, `mypy`, and `pylint` (10.00/10) all pass on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate recommendation findings when a class is split into components, so results are cleaner and importance scores are no longer inflated by repeated matches.
  * Improved handling of repeated pattern/code-line combinations while still keeping distinct findings.

* **Tests**
  * Added coverage for decomposition-based recommendations to verify duplicate results are removed and unique ones remain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->