### PR TITLE
854: Use inline Java in assert pattern test

### DIFF
--- a/test/patterns/assert_in_code/Book.java
+++ b/test/patterns/assert_in_code/Book.java
@@ -1,8 +1,0 @@
-// SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
-// SPDX-License-Identifier: MIT
-
-class Book {
-  void foo(String x) {
-    assert x != null; // here
-  }
-}

--- a/test/patterns/assert_in_code/test_assert_in_code.py
+++ b/test/patterns/assert_in_code/test_assert_in_code.py
@@ -1,19 +1,24 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
 # SPDX-License-Identifier: MIT
 
-import os.path
-from pathlib import Path
+from textwrap import dedent
 from unittest import TestCase
 
 from aibolit.patterns.assert_in_code.assert_in_code import AssertInCode
 from aibolit.ast_framework import AST
-from aibolit.utils.ast_builder import build_ast
+from aibolit.utils.ast_builder import build_ast_from_string
 
 
 class AssertInCodeTestCase(TestCase):
-    cur_file_dir = Path(os.path.realpath(__file__)).parent
-
     def test_assert_in_code(self):
-        file = Path(self.cur_file_dir, 'Book.java')
-        ast = AST.build_from_javalang(build_ast(file))
-        self.assertEqual(AssertInCode().value(ast), [6])
+        content = dedent(
+            '''\
+            class Book {
+              void foo(String x) {
+                assert x != null; // here
+              }
+            }
+            '''
+        )
+        ast = AST.build_from_javalang(build_ast_from_string(content))
+        self.assertEqual(AssertInCode().value(ast), [3])


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated an assertion-related test to use inline sample code, making the test self-contained.
  * Adjusted the expected result to match the new sample input.

* **Chores**
  * Removed an unused test fixture file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->