### PR TITLE
Fix Issue 599. Explain maintainability metric value computation

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,19 +325,6 @@ located in `TARGET_FOLDER/target`.*
      ```
 
 Or you can use our [docker image](https://hub.docker.com/r/yegor256/aibolit-image)
-to run the ML pipeline without installing the full toolchain locally.
-
-Start the development image with input and output directories mounted:
-
-```bash
-docker run --rm -it --name aibolit-train-model \
-  -v <absolute_path_to_dataset_folder>:/home/jovyan/in \
-  -v <absolute_path_to_output_folder>:/home/jovyan/out \
-  -m=4g --user root -e NB_UID=`id -u` yegor256/aibolit-image-dev
-```
-
-Inside the container, use `/home/jovyan/in` for input Java sources or prepared
-datasets and `/home/jovyan/out` for generated datasets and model files.
 
 Run train pipeline:
 

--- a/README.md
+++ b/README.md
@@ -329,14 +329,14 @@ Or you can use our [docker image](https://hub.docker.com/r/yegor256/aibolit-imag
 Run train pipeline:
 
 ```bash
-aibolit train --java_folder=/home/jovyan/in [--max_classes=100] [--dataset_file]
+aibolit train --java_folder=src/java [--max_classes=100] [--dataset_file]
 ```
 
 If you need to save the dataset with all calculated metrics to a different
 directory, you need to use `dataset_file` parameter
 
 ```bash
-aibolit train --java_folder=/home/jovyan/in --dataset_file /home/jovyan/out/dataset.csv
+aibolit train --java_folder=src/java --dataset_file mnt/d/new_dir/dataset.csv
 ```
 
 You can skip dataset collection with `skip_collect_dataset` parameter. In
@@ -344,7 +344,7 @@ this case
 the model will be trained with predefined dataset (see 5 point):
 
 ```bash
-aibolit train --java_folder=/home/jovyan/in --skip_collect_dataset
+aibolit train --java_folder=src/java --skip_collect_dataset
 ```
 
 ## How to contribute?

--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ If you need to save the dataset with all calculated metrics to a different
 directory, you need to use `dataset_file` parameter
 
 ```bash
-aibolit train --java_folder=src/java --dataset_file mnt/d/new_dir/dataset.csv
+aibolit train --java_folder=src/java --dataset_file /mnt/d/new_dir/dataset.csv
 ```
 
 You can skip dataset collection with `skip_collect_dataset` parameter. In

--- a/README.md
+++ b/README.md
@@ -325,18 +325,31 @@ located in `TARGET_FOLDER/target`.*
      ```
 
 Or you can use our [docker image](https://hub.docker.com/r/yegor256/aibolit-image)
+to run the ML pipeline without installing the full toolchain locally.
+
+Start the development image with input and output directories mounted:
+
+```bash
+docker run --rm -it --name aibolit-train-model \
+  -v <absolute_path_to_dataset_folder>:/home/jovyan/in \
+  -v <absolute_path_to_output_folder>:/home/jovyan/out \
+  -m=4g --user root -e NB_UID=`id -u` yegor256/aibolit-image-dev
+```
+
+Inside the container, use `/home/jovyan/in` for input Java sources or prepared
+datasets and `/home/jovyan/out` for generated datasets and model files.
 
 Run train pipeline:
 
 ```bash
-aibolit train --java_folder=src/java [--max_classes=100] [--dataset_file]
+aibolit train --java_folder=/home/jovyan/in [--max_classes=100] [--dataset_file]
 ```
 
 If you need to save the dataset with all calculated metrics to a different
 directory, you need to use `dataset_file` parameter
 
 ```bash
-aibolit train --java_folder=src/java --dataset_file /mnt/d/new_dir/dataset.csv
+aibolit train --java_folder=/home/jovyan/in --dataset_file /home/jovyan/out/dataset.csv
 ```
 
 You can skip dataset collection with `skip_collect_dataset` parameter. In
@@ -344,7 +357,7 @@ this case
 the model will be trained with predefined dataset (see 5 point):
 
 ```bash
-aibolit train --java_folder=src/java --skip_collect_dataset
+aibolit train --java_folder=/home/jovyan/in --skip_collect_dataset
 ```
 
 ## How to contribute?

--- a/wp/sections/how_aibolit_works.tex
+++ b/wp/sections/how_aibolit_works.tex
@@ -59,6 +59,16 @@ In the current release of Aibolit, we use Cognitive Complexity \citep{10.1145/31
 the maintainability metric. We refer to it as the maintainability metric or just
 metric in the remainder of the text.
 
+For a class $C$, the raw metric value $M(C)$ is computed by traversing the AST
+of each method and summing Cognitive Complexity increments. Control-flow nodes
+such as \texttt{if}, \texttt{switch}, \texttt{for}, \texttt{while},
+\texttt{do}, and \texttt{catch} add $1$ plus the current nesting level.
+Other flow-breaking constructs, including \texttt{break}, \texttt{continue},
+ternary expressions, recursion calls, and sequences of logical operators, add
+$1$ without an extra nesting penalty. The class metric is the sum of these
+values over all methods. During dataset preprocessing, the target value is
+normalized by class size as $t^C = M(C) / \textit{NCSS}(C)$.
+
 \subsection{Maintainability prediction model}
 
 \label{sec:maint_pred_model}


### PR DESCRIPTION
Closes #599

Explains how the white paper computes the maintainability metric value:
- describes raw Cognitive Complexity calculation;
- clarifies per-class aggregation;
- documents NCSS normalization used for the target value.