### PR TITLE
fix(#599): clarify metric value meaning

### DIFF
--- a/wp/sections/how_aibolit_works.tex
+++ b/wp/sections/how_aibolit_works.tex
@@ -18,7 +18,8 @@ of the input Java class.
 \vspace{1 cm}
 \caption{How Aibolit works: (1) Inspect the source code for patterns.
 (2) Count the pattern occurrences and put them in a vector representation.
-Compute the maintainability metric value for the vector.
+Compute the maintainability metric value for the original class; in our dataset,
+this value is Cognitive Complexity divided by NCSS.
 (3) Consider changes to the vector representation by subtracting pattern counts.
 Predict the corresponding maintainability metric score.
 (4) Rank all the alternative vectors with respect to how much they improve the original


### PR DESCRIPTION
This closes #599.

The description of the maintainability metric value was too vague and could be read as an opaque score.

What is changed here:
- state explicitly that the value is Cognitive Complexity divided by NCSS
- keep the rest of the explanation intact

This makes the metric definition easier to understand for first-time readers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the “How Aibolit works” workflow.
  * Specified that maintainability is calculated for the original class as Cognitive Complexity divided by NCSS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->