### PR TITLE
fix(#600): clarify recommendation ranking

### DIFF
--- a/wp/sections/how_aibolit_works.tex
+++ b/wp/sections/how_aibolit_works.tex
@@ -145,7 +145,9 @@ Our recommendation algorithm ranks
 patterns observed in the user's source class according to their individual
 impact on the code's maintainability metric value. It then outputs a pattern
 with the \textit{most negative impact} as a recommendation to the user to remove
-it from their code.
+it from their code. In other words, rank 1 corresponds to the pattern whose
+count decreased by one yields the largest predicted improvement of the
+maintainability score.
 
 For each pattern $p$ we compute the \textbf{impact factor} $I_{\textit{neg}}(p, C)$
 on code $C$, which is intended to capture the \textit{negative


### PR DESCRIPTION
This closes #600.

The ranking explanation did not clearly say what the top recommendation means.

What is changed here:
- explain that rank 1 corresponds to the pattern removal with the largest predicted maintainability improvement
- keep the wording aligned with the surrounding recommendation description

This makes the output ordering easier to interpret.