### PR TITLE
fix(#319): document docker train pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,18 @@ Run train pipeline:
 aibolit train --java_folder=src/java [--max_classes=100] [--dataset_file]
 ```
 
+The same training pipeline can be executed in Docker:
+
+```bash
+docker run --rm -it --name aibolit-train-model \
+  -v <absolute_path_to_dataset_folder>:/home/jovyan/in \
+  -v <absolute_path_to_output_folder>:/home/jovyan/out \
+  -m=4g --user root -e NB_UID=`id -u` yegor256/aibolit-image-dev
+```
+
+Inside the container, use `/home/jovyan/in` as the input dataset directory and
+`/home/jovyan/out` as the output directory for generated artifacts.
+
 If you need to save the dataset with all calculated metrics to a different
 directory, you need to use `dataset_file` parameter
 


### PR DESCRIPTION
This closes #319.

The README documents how to run the detector in Docker, but not how to run the training pipeline the same way.

What is changed here:
- add a Docker example for `scripts/train_process.py`
- document the expected input and output mount points

This gives contributors a minimal reproducible way to run training without setting up the full local environment first.