### PR TITLE
fix(#1274): detect actual getters and setters

### DIFF
--- a/aibolit/utils/filter.py
+++ b/aibolit/utils/filter.py
@@ -14,6 +14,7 @@ from javalang.tree import (
     Node,
     ReturnStatement,
     This,
+    StatementExpression,
 )
 
 FldExh = Tuple[str, Tuple[str, str]]
@@ -85,15 +86,22 @@ class Filters:
         if (
             not method_node.name.startswith('set') or  # type: ignore[unresolved-attribute]
             method_node.return_type is not None or  # type: ignore[unresolved-attribute]
-            not method_node.parameters  # type: ignore[unresolved-attribute]
+            len(method_node.parameters) != 1  # type: ignore[unresolved-attribute]
         ):
             return False
+        body = [
+            statement
+            for statement in (method_node.body or [])  # type: ignore[unresolved-attribute]
+            if not isinstance(statement, AssertStatement)
+        ]
+        if len(body) != 1 or not isinstance(body[0], StatementExpression):
+            return False
+        expression = body[0].expression
+        if not isinstance(expression, Assignment):
+            return False
+        value = expression.value
         parameter = method_node.parameters[0].name  # type: ignore[unresolved-attribute]
-        for _, assignment in method_node.filter(Assignment):
-            value = assignment.value
-            if isinstance(value, MemberReference) and value.member == parameter:
-                return True
-        return False
+        return isinstance(value, MemberReference) and value.member == parameter
 
     @staticmethod
     def get_class_depth(path: tuple) -> int:

--- a/aibolit/utils/filter.py
+++ b/aibolit/utils/filter.py
@@ -1,8 +1,20 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
 # SPDX-License-Identifier: MIT
 from typing import List, Tuple, Any, Union, TypeVar, Type
-from javalang.tree import ClassDeclaration, InterfaceDeclaration, MethodDeclaration, \
-    MemberReference, FieldDeclaration, MethodInvocation, This, Node, LocalVariableDeclaration
+from javalang.tree import (
+    AssertStatement,
+    Assignment,
+    ClassDeclaration,
+    FieldDeclaration,
+    InterfaceDeclaration,
+    LocalVariableDeclaration,
+    MemberReference,
+    MethodDeclaration,
+    MethodInvocation,
+    Node,
+    ReturnStatement,
+    This,
+)
 
 FldExh = Tuple[str, Tuple[str, str]]
 MthExh = Tuple[str, Tuple[Tuple[str, str], ...]]
@@ -35,22 +47,53 @@ class Filters:
 
     @staticmethod
     def filter_getters_setters(method_node_list: List[MthNodes]) -> List[MthNodes]:
-        '''Filters nodes by name.
+        """Filter actual getter and setter methods.
 
-        Gets list of nodes of "MethodDeclaration" type and filters it by
-        name, so that no methods with name starting with "set" or "get"
-        go to return list.
-        Returns a generator with (path, node) inside.
-        '''
+        Methods whose names merely start with ``get`` or ``set`` remain
+        in the returned list unless their bodies match accessor behavior.
+        """
+        return [
+            (path, node)
+            for path, node in method_node_list
+            if not Filters._is_getter(node) and not Filters._is_setter(node)
+        ]
 
-        # To-Fix: implement get/set detection with .body
-        temp_list = []
-        for path, node in method_node_list:
-            if node.name.startswith(('get', 'set')):  # type: ignore[unresolved-attribute]
-                pass
-            else:
-                temp_list.append((path, node))
-        return temp_list
+    @staticmethod
+    def _is_getter(method_node: MethodDeclaration) -> bool:
+        """Check whether a method is a getter."""
+        if not method_node.name.startswith('get'):  # type: ignore[unresolved-attribute]
+            return False
+        body = [
+            statement
+            for statement in (method_node.body or [])  # type: ignore[unresolved-attribute]
+            if not isinstance(statement, AssertStatement)
+        ]
+        if len(body) != 1 or not isinstance(body[0], ReturnStatement):
+            return False
+        expression = getattr(body[0], 'expression', None)
+        direct_member = isinstance(expression, MemberReference)
+        this_member = (
+            isinstance(expression, This) and
+            len(expression.selectors or []) == 1 and
+            isinstance(expression.selectors[0], MemberReference)
+        )
+        return direct_member or this_member
+
+    @staticmethod
+    def _is_setter(method_node: MethodDeclaration) -> bool:
+        """Check whether a method is a setter."""
+        if (
+            not method_node.name.startswith('set') or  # type: ignore[unresolved-attribute]
+            method_node.return_type is not None or  # type: ignore[unresolved-attribute]
+            not method_node.parameters  # type: ignore[unresolved-attribute]
+        ):
+            return False
+        parameter = method_node.parameters[0].name  # type: ignore[unresolved-attribute]
+        for _, assignment in method_node.filter(Assignment):
+            value = assignment.value
+            if isinstance(value, MemberReference) and value.member == parameter:
+                return True
+        return False
 
     @staticmethod
     def get_class_depth(path: tuple) -> int:

--- a/test/metrics/lcom4/FalseGetterSetter.java
+++ b/test/metrics/lcom4/FalseGetterSetter.java
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+// SPDX-License-Identifier: MIT
+
+package javalang.brewtab.com;
+
+public class FalseGetterSetter {
+
+    private int first;
+
+    private int second;
+
+    public void setup() {
+        first++;
+        second++;
+    }
+
+    public int getaway() {
+        first++;
+        return second;
+    }
+
+    public void useFirst() {
+        first++;
+    }
+
+    public void useSecond() {
+        second++;
+    }
+}

--- a/test/metrics/lcom4/test_lcom4.py
+++ b/test/metrics/lcom4/test_lcom4.py
@@ -56,3 +56,8 @@ class TestLCOM4(TestCase):
         name = 'OverloadedDiffComp.java'
         lcom4_val = self.pattern.value(Path(self.dir_path, name))
         self.assertEqual(lcom4_val, 1)
+
+    def test_methods_starting_with_get_or_set_are_not_accessors(self):
+        name = 'FalseGetterSetter.java'
+        lcom4_val = self.pattern.value(Path(self.dir_path, name))
+        self.assertEqual(lcom4_val, 1)


### PR DESCRIPTION
Closes #1274.

## Changes

- detect getters and setters by their method bodies instead of name prefixes only;
- keep ordinary methods such as `setup()` and `getaway()` in the LCOM4 cohesion graph;
- add a regression test covering false `get`/`set` prefix matches.

## Tests

- `uv run --frozen pytest test/metrics/lcom4/test_lcom4.py -q` — 10 passed;
- `flake8` — passed;
- `pylint` — 10.00/10;
- `mypy` — passed;
- `ruff check` — passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved getter/setter recognition used by the LCOM4 metric.
  * Methods whose names start with “get” or “set” are no longer misclassified; detection now uses method structure/behavior to determine true accessors.

* **Tests**
  * Added a new Java fixture with misleading “get/set” methods.
  * Added a unit test asserting the LCOM4 value for the new fixture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->