### PR TITLE
#896: Replace ty lint target with pyright

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,11 @@
 .SHELLFLAGS := -e -o pipefail -c
 .SECONDARY:
 SHELL := bash
-.PHONY: all clean requirements test it install xcop flake8 pylint bandit sphinx mypy lint e2e build coverage ruff ty
+.PHONY: all clean requirements test it install xcop flake8 pylint bandit sphinx mypy lint e2e build coverage ruff pyright
 
 all: requirements install test it lint sphinx
 
-lint: flake8 pylint mypy ruff bandit ty xcop
+lint: flake8 pylint mypy ruff bandit pyright xcop
 
 requirements:
 	uv sync
@@ -45,8 +45,8 @@ bandit:
 ruff:
 	uv run ruff check .
 
-ty:
-	uvx ty==0.0.1-alpha.8 check
+pyright:
+	uvx pyright==1.1.411
 
 sphinx:
 	rm -rf sphinx html

--- a/aibolit/metrics/halsteadvolume/pom.xml
+++ b/aibolit/metrics/halsteadvolume/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
- * SPDX-License-Identifier: MIT
+SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+SPDX-License-Identifier: MIT
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0     http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>

--- a/aibolit/metrics/npath/npath.xml
+++ b/aibolit/metrics/npath/npath.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
- * SPDX-License-Identifier: MIT
+SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+SPDX-License-Identifier: MIT
 -->
 <ruleset xmlns="http://pmd.sourceforge.net/ruleset/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="quickstart" xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
   <description>Quickstart configuration of PMD. Includes the rules that are most likely to apply everywhere.</description>

--- a/aibolit/metrics/npath/pom.xml
+++ b/aibolit/metrics/npath/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
- * SPDX-License-Identifier: MIT
+SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+SPDX-License-Identifier: MIT
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,24 @@ build-backend = "setuptools.build_meta"
 [tool.mypy]
 mypy_path = "stubs"
 
+[tool.pyright]
+include = ["aibolit"]
+exclude = ["stubs", "test", "scripts/target"]
+reportArgumentType = "none"
+reportAttributeAccessIssue = "none"
+reportAssignmentType = "none"
+reportCallIssue = "none"
+reportGeneralTypeIssues = "none"
+reportIndexIssue = "none"
+reportMissingImports = "none"
+reportMissingModuleSource = "none"
+reportOperatorIssue = "none"
+reportOptionalMemberAccess = "none"
+reportOptionalSubscript = "none"
+reportReturnType = "none"
+reportUnhashable = "none"
+typeCheckingMode = "basic"
+
 [tool.bandit]
 # B301: pickle.load is used only to deserialize the bundled model file
 # (aibolit/binary_files/model.pkl) that ships with the package, not

--- a/scripts/ruleset.xml
+++ b/scripts/ruleset.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
- * SPDX-License-Identifier: MIT
+SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+SPDX-License-Identifier: MIT
 -->
 <ruleset xmlns="http://pmd.sourceforge.net/ruleset/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="quickstart" xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
   <description>Quickstart configuration of PMD. Includes the rules that are most likely to apply everywhere.</description>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated project linting/type checks to use Pyright instead of the previous tool.
  * Added Pyright configuration to control type-checking scope and diagnostic verbosity.
  * Pinned the Pyright version used by the project’s checks.
  * Reformatted SPDX headers in XML configuration files and Maven POMs without changing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->