### PR TITLE
#697: Prune virtualenv directories in xcop target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ it:
 xcop:
 	while IFS= read -r f; do
 		xcop "$${f}"
-	done < <(find . -name '*.xml' -not -path './.venv/**' -not -path './wp/**')
+	done < <(find . \( -path './.venv' -o -path './.env' -o -path './wp' \) -prune -o -name '*.xml' -type f -print)
 
 flake8:
 	uv run flake8 aibolit test scripts --exclude scripts/target/*

--- a/aibolit/metrics/halsteadvolume/pom.xml
+++ b/aibolit/metrics/halsteadvolume/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
- * SPDX-License-Identifier: MIT
+SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+SPDX-License-Identifier: MIT
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0     http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>

--- a/aibolit/metrics/npath/npath.xml
+++ b/aibolit/metrics/npath/npath.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
- * SPDX-License-Identifier: MIT
+SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+SPDX-License-Identifier: MIT
 -->
 <ruleset xmlns="http://pmd.sourceforge.net/ruleset/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="quickstart" xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
   <description>Quickstart configuration of PMD. Includes the rules that are most likely to apply everywhere.</description>

--- a/aibolit/metrics/npath/pom.xml
+++ b/aibolit/metrics/npath/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
- * SPDX-License-Identifier: MIT
+SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+SPDX-License-Identifier: MIT
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>

--- a/scripts/ruleset.xml
+++ b/scripts/ruleset.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
- * SPDX-License-Identifier: MIT
+SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+SPDX-License-Identifier: MIT
 -->
 <ruleset xmlns="http://pmd.sourceforge.net/ruleset/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="quickstart" xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
   <description>Quickstart configuration of PMD. Includes the rules that are most likely to apply everywhere.</description>

--- a/test/test_makefile.py
+++ b/test/test_makefile.py
@@ -13,7 +13,7 @@ def test_xcop_find_prunes_excluded_directories(tmp_path):
         (excluded / 'launcher manifest.xml').write_text('<xml/>', encoding='utf-8')
 
     result = subprocess.run(
-        ['bash', '-lc', _xcop_find_command()],
+        ['bash', '-c', _xcop_find_command()],
         cwd=tmp_path,
         check=True,
         stdout=subprocess.PIPE,

--- a/test/test_makefile.py
+++ b/test/test_makefile.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+# SPDX-License-Identifier: MIT
+
+import subprocess
+from pathlib import Path
+
+
+def test_xcop_find_prunes_excluded_directories(tmp_path):
+    (tmp_path / 'pom.xml').write_text('<project/>', encoding='utf-8')
+    for directory in ('.venv', '.env', 'wp'):
+        excluded = tmp_path / directory
+        excluded.mkdir()
+        (excluded / 'launcher manifest.xml').write_text('<xml/>', encoding='utf-8')
+
+    result = subprocess.run(
+        ['bash', '-lc', _xcop_find_command()],
+        cwd=tmp_path,
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+
+    assert result.stdout.splitlines() == ['./pom.xml']
+
+
+def _xcop_find_command() -> str:
+    makefile = Path(__file__).resolve().parents[1] / 'Makefile'
+    for line in makefile.read_text(encoding='utf-8').splitlines():
+        stripped = line.strip()
+        if stripped.startswith('done < <(') and stripped.endswith(')'):
+            return stripped.removeprefix('done < <(')[:-1]
+    raise AssertionError('Cannot find xcop find command in Makefile')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated XML file discovery to exclude files in `.env`, `.venv`, and `wp` directories, preventing unintended files from being processed.

* **Tests**
  * Added coverage to verify that excluded directories are correctly omitted from XML processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->