### PR TITLE
#344: Validate XML reports against XSD schema

### DIFF
--- a/aibolit/__main__.py
+++ b/aibolit/__main__.py
@@ -16,6 +16,7 @@ import sys
 import time
 import traceback
 from collections import defaultdict, OrderedDict
+from importlib import resources
 from os import scandir
 from pathlib import Path
 from sys import stdout
@@ -39,6 +40,7 @@ from aibolit.ml_pipeline.ml_pipeline import train_process, collect_dataset
 from aibolit.utils.ast_builder import build_ast
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
+REPORT_SCHEMA = 'report.xsd'
 
 
 def list_dir(path, files):
@@ -637,6 +639,13 @@ def create_xml_tree(results, full_report, cmd, exit_code):
     return top
 
 
+def validate_xml_report(root):
+    """Validate an XML report against the bundled XSD schema."""
+    schema_path = resources.files('aibolit').joinpath(REPORT_SCHEMA)
+    schema = etree.XMLSchema(etree.parse(str(schema_path)))
+    schema.assertValid(root)
+
+
 def get_exit_code(results):
     """
     Analyzed recommendation results and generate exit_code for pipeline
@@ -804,6 +813,7 @@ def recommend():
     if args.format:
         if args.format == 'xml':
             root = create_xml_tree(results, args.full, sys.argv, exit_code)
+            validate_xml_report(root)
             tree = root.getroottree()
             tree.write(stdout.buffer, pretty_print=True)
         else:

--- a/aibolit/metrics/halsteadvolume/pom.xml
+++ b/aibolit/metrics/halsteadvolume/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
- * SPDX-License-Identifier: MIT
+SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+SPDX-License-Identifier: MIT
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0     http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>

--- a/aibolit/metrics/npath/npath.xml
+++ b/aibolit/metrics/npath/npath.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
- * SPDX-License-Identifier: MIT
+SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+SPDX-License-Identifier: MIT
 -->
 <ruleset xmlns="http://pmd.sourceforge.net/ruleset/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="quickstart" xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
   <description>Quickstart configuration of PMD. Includes the rules that are most likely to apply everywhere.</description>

--- a/aibolit/metrics/npath/pom.xml
+++ b/aibolit/metrics/npath/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
- * SPDX-License-Identifier: MIT
+SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+SPDX-License-Identifier: MIT
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>

--- a/aibolit/report.xsd
+++ b/aibolit/report.xsd
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+SPDX-License-Identifier: MIT
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="report">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="header" type="headerType"/>
+        <xs:element name="files" type="filesType"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:complexType name="headerType">
+    <xs:sequence>
+      <xs:element name="score" type="xs:string"/>
+      <xs:element name="datetime" type="xs:nonNegativeInteger"/>
+      <xs:element name="version" type="xs:string"/>
+      <xs:element name="files" type="xs:nonNegativeInteger"/>
+      <xs:element name="patterns" type="xs:nonNegativeInteger"/>
+      <xs:element name="ncss" type="xs:nonNegativeInteger"/>
+      <xs:element name="cmd" type="xs:string"/>
+      <xs:element name="exit_code" type="xs:integer"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="filesType">
+    <xs:sequence>
+      <xs:element name="file" type="fileType" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="fileType">
+    <xs:sequence>
+      <xs:element name="path" type="xs:string"/>
+      <xs:element name="summary" type="xs:string"/>
+      <xs:element name="score" type="xs:string" minOccurs="0"/>
+      <xs:element name="patterns" type="patternsType" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="patternsType">
+    <xs:sequence>
+      <xs:element name="pattern" type="patternType" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="patternType">
+    <xs:sequence>
+      <xs:element name="details" type="xs:string"/>
+      <xs:element name="score" type="xs:decimal"/>
+      <xs:element name="order" type="xs:string"/>
+      <xs:element name="lines" type="linesType" minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="code" type="xs:string" use="required"/>
+  </xs:complexType>
+
+  <xs:complexType name="linesType">
+    <xs:sequence>
+      <xs:element name="number" type="xs:integer" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+</xs:schema>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,8 @@ include-package-data = true
 [tool.setuptools.package-data]
 aibolit = [
   "binary_files/halstead.jar",
-  "binary_files/model.dat"
+  "binary_files/model.dat",
+  "report.xsd",
 ]
 
 [tool.setuptools.dynamic]

--- a/scripts/ruleset.xml
+++ b/scripts/ruleset.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
- * SPDX-License-Identifier: MIT
+SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+SPDX-License-Identifier: MIT
 -->
 <ruleset xmlns="http://pmd.sourceforge.net/ruleset/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="quickstart" xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
   <description>Quickstart configuration of PMD. Includes the rules that are most likely to apply everywhere.</description>

--- a/test/recommend/test_recommend_pipeline.py
+++ b/test/recommend/test_recommend_pipeline.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 
 import javalang
 import javalang.tree
-from lxml import etree
+from lxml import etree  # type: ignore[import-untyped]
 
 from aibolit import __main__ as aibolit_main
 from aibolit.config import Config

--- a/test/recommend/test_recommend_pipeline.py
+++ b/test/recommend/test_recommend_pipeline.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 
 import javalang
 import javalang.tree
+from lxml import etree
 
 from aibolit import __main__ as aibolit_main
 from aibolit.config import Config
@@ -16,7 +17,7 @@ from aibolit.config import Config
 from aibolit.__main__ import list_dir, calculate_patterns_and_metrics, \
     create_xml_tree, create_text, format_converter_for_pattern, find_start_and_end_lines, \
     find_annotation_by_node_type, add_pattern_if_ignored, _process_components, \
-    run_recommend_for_file
+    run_recommend_for_file, validate_xml_report
 
 
 class TestRecommendPipeline(TestCase):
@@ -152,19 +153,26 @@ class TestRecommendPipeline(TestCase):
     def test_xml_create_full_report(self):
         mock_input = self.__create_input_for_xml()
         mock_cmd = self.__create_mock_cmd()
-        create_xml_tree(mock_input, full_report=True, cmd=mock_cmd, exit_code=0)
+        root = create_xml_tree(mock_input, full_report=True, cmd=mock_cmd, exit_code=0)
+        validate_xml_report(root)
 
     def test_xml_empty_results(self):
         mock_cmd = self.__create_mock_cmd()
-        create_xml_tree([], full_report=True, cmd=mock_cmd, exit_code=0)
+        root = create_xml_tree([], full_report=True, cmd=mock_cmd, exit_code=0)
+        validate_xml_report(root)
 
     def test_xml(self):
         mock_input = self.__create_mock_input()
         mock_cmd = self.__create_mock_cmd()
         root = create_xml_tree(mock_input, full_report=True, cmd=mock_cmd, exit_code=2)
+        validate_xml_report(root)
 
         self.assertEqual(root.findtext('./header/patterns'), '5')
         self.assertEqual(len(root.findall('./files/file/patterns/pattern')), 5)
+
+    def test_xml_validation_rejects_invalid_report(self):
+        with self.assertRaises(Exception):
+            validate_xml_report(etree.Element('report'))
 
     def test_count_value_keeps_original_exception_context(self):
         value_dict = {

--- a/test/scripts/test_calculate_metrics.py
+++ b/test/scripts/test_calculate_metrics.py
@@ -12,8 +12,9 @@ def load_calculate_metrics_module():
         raise RuntimeError(f'Failed to load module spec from {script_path}')
     if spec.loader is None:
         raise RuntimeError(f'Failed to load module loader from {script_path}')
+    loader = spec.loader
     module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
+    loader.exec_module(module)
     return module
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added schema validation for XML recommendation reports before they are displayed.
  * Added a formal XML report schema defining report structure, metadata, files, patterns, and line details.
  * Included the schema in packaged distributions.

* **Bug Fixes**
  * Invalid XML reports are now detected before output.

* **Tests**
  * Added coverage for valid, empty, and invalid XML reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->