### PR TITLE
#286: Implement external methods called metric

### DIFF
--- a/aibolit/metrics/external_methods_called/external_methods_called.py
+++ b/aibolit/metrics/external_methods_called/external_methods_called.py
@@ -1,11 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
 # SPDX-License-Identifier: MIT
-import itertools
-import os
 from dataclasses import dataclass
-from typing import Iterator
+from typing import Set
 
-from aibolit.ast_framework import AST, ASTNode, ASTNodeType
+from aibolit.ast_framework import AST, ASTNodeType
 from aibolit.utils.ast_builder import build_ast
 
 
@@ -14,11 +12,10 @@ class ExternalMethodsCalled:
     Measure the number of external methods called by the class.
     """
 
-    def __init__(self):
-        pass
-
-    def value(self, filepath: str | os.PathLike):
-        return ExternalMethodsCalledCount(AST.build_from_javalang(build_ast(filepath))).total()
+    def value(self, ast: AST) -> int:
+        if not isinstance(ast, AST):
+            ast = AST.build_from_javalang(build_ast(ast))
+        return ExternalMethodsCalledCount(ast).total()
 
 
 @dataclass(frozen=True)
@@ -28,23 +25,16 @@ class ExternalMethodsCalledCount:
     def total(self) -> int:
         return len(set(self._external_method_names_called()))
 
-    def _external_method_names_called(self) -> Iterator[str]:
-        for node in self._parent_method_invocation_nodes():
-            for first, second in itertools.pairwise(node.children):
-                if self._member_reference_followed_by_method_invocation(first, second):
-                    yield second.member
+    def _external_method_names_called(self) -> Set[str]:
+        local_methods = self._local_method_names()
+        return set(
+            node.member
+            for node in self.ast.proxy_nodes(ASTNodeType.METHOD_INVOCATION)
+            if node.member not in local_methods
+        )
 
-    def _parent_method_invocation_nodes(self) -> Iterator[ASTNode]:
-        for node in self.ast.proxy_nodes(ASTNodeType.METHOD_INVOCATION):
-            if (parent := node.parent) is not None:
-                yield parent
-
-    def _member_reference_followed_by_method_invocation(
-        self,
-        first: ASTNode,
-        second: ASTNode,
-    ) -> bool:
-        return (
-            first.node_type == ASTNodeType.MEMBER_REFERENCE and
-            second.node_type == ASTNodeType.METHOD_INVOCATION
+    def _local_method_names(self) -> Set[str]:
+        return set(
+            node.name
+            for node in self.ast.proxy_nodes(ASTNodeType.METHOD_DECLARATION)
         )

--- a/aibolit/metrics/external_methods_called/external_methods_called.py
+++ b/aibolit/metrics/external_methods_called/external_methods_called.py
@@ -29,7 +29,10 @@ class ExternalMethodsCalledCount:
         local_methods = self._local_method_names()
         return set(
             node.member
-            for node in self.ast.proxy_nodes(ASTNodeType.METHOD_INVOCATION)
+            for node in self.ast.proxy_nodes(
+                ASTNodeType.METHOD_INVOCATION,
+                ASTNodeType.SUPER_METHOD_INVOCATION,
+            )
             if node.member not in local_methods
         )
 

--- a/aibolit/metrics/halsteadvolume/pom.xml
+++ b/aibolit/metrics/halsteadvolume/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
- * SPDX-License-Identifier: MIT
+SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+SPDX-License-Identifier: MIT
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0     http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>

--- a/aibolit/metrics/npath/npath.xml
+++ b/aibolit/metrics/npath/npath.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
- * SPDX-License-Identifier: MIT
+SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+SPDX-License-Identifier: MIT
 -->
 <ruleset xmlns="http://pmd.sourceforge.net/ruleset/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="quickstart" xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
   <description>Quickstart configuration of PMD. Includes the rules that are most likely to apply everywhere.</description>

--- a/aibolit/metrics/npath/pom.xml
+++ b/aibolit/metrics/npath/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
- * SPDX-License-Identifier: MIT
+SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+SPDX-License-Identifier: MIT
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>

--- a/scripts/ruleset.xml
+++ b/scripts/ruleset.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
- * SPDX-License-Identifier: MIT
+SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+SPDX-License-Identifier: MIT
 -->
 <ruleset xmlns="http://pmd.sourceforge.net/ruleset/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="quickstart" xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
   <description>Quickstart configuration of PMD. Includes the rules that are most likely to apply everywhere.</description>

--- a/test/metrics/external_methods_called/LocalMethodCall.java
+++ b/test/metrics/external_methods_called/LocalMethodCall.java
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+// SPDX-License-Identifier: MIT
+
+public class LocalMethodCall {
+
+    public String value() {
+        return "value";
+    }
+
+    public String call() {
+        return this.value();
+    }
+}

--- a/test/metrics/external_methods_called/SuperMethodCall.java
+++ b/test/metrics/external_methods_called/SuperMethodCall.java
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+// SPDX-License-Identifier: MIT
+
+public class SuperMethodCall {
+
+    public String value() {
+        return super.toString();
+    }
+}

--- a/test/metrics/external_methods_called/test_external_methods_called.py
+++ b/test/metrics/external_methods_called/test_external_methods_called.py
@@ -5,7 +5,9 @@ import os
 from pathlib import Path
 from unittest import TestCase
 
+from aibolit.ast_framework import AST
 from aibolit.metrics.external_methods_called.external_methods_called import ExternalMethodsCalled
+from aibolit.utils.ast_builder import build_ast
 
 
 class ExternalMethodsCalledTest(TestCase):
@@ -13,32 +15,45 @@ class ExternalMethodsCalledTest(TestCase):
 
     def test_no_external_method_calls(self):
         self.assertEqual(
-            ExternalMethodsCalled().value(Path(self.dir_path, 'NoExternalMethodCalls.java')),
+            ExternalMethodsCalled().value(self._ast('NoExternalMethodCalls.java')),
             0,
             'Could not calculate how many external methods are called when none'
         )
 
     def test_external_method_calls(self):
         self.assertEqual(
-            ExternalMethodsCalled().value(Path(self.dir_path, 'ExternalMethodCalls.java')),
+            ExternalMethodsCalled().value(self._ast('ExternalMethodCalls.java')),
             2,
             'Could not calculate how many external method are called when they exist'
         )
 
+    def test_external_method_calls_from_filepath(self):
+        self.assertEqual(
+            ExternalMethodsCalled().value(Path(self.dir_path, 'ExternalMethodCalls.java')),
+            2,
+            'Could not calculate external methods from a file path'
+        )
+
     def test_inner_class_external_method_calls(self):
         self.assertEqual(
-            ExternalMethodsCalled().value(
-                Path(self.dir_path, 'InnerClassExternalMethodCalls.java')
-            ),
+            ExternalMethodsCalled().value(self._ast('InnerClassExternalMethodCalls.java')),
             1,
             'Could not calculate how many external methods called when they exist in inner class'
         )
 
     def test_double_external_method_calls(self):
         self.assertEqual(
-            ExternalMethodsCalled().value(
-                Path(self.dir_path, 'DoubleExternalMethodCalls.java')
-            ),
+            ExternalMethodsCalled().value(self._ast('DoubleExternalMethodCalls.java')),
             1,
             'Could not calculate external methods called when they are called more than once'
         )
+
+    def test_local_method_call_is_not_external(self):
+        self.assertEqual(
+            ExternalMethodsCalled().value(self._ast('LocalMethodCall.java')),
+            0,
+            'Could not ignore local method calls'
+        )
+
+    def _ast(self, filename):
+        return AST.build_from_javalang(build_ast(Path(self.dir_path, filename)))

--- a/test/metrics/external_methods_called/test_external_methods_called.py
+++ b/test/metrics/external_methods_called/test_external_methods_called.py
@@ -29,7 +29,9 @@ class ExternalMethodsCalledTest(TestCase):
 
     def test_external_method_calls_from_filepath(self):
         self.assertEqual(
-            ExternalMethodsCalled().value(Path(self.dir_path, 'ExternalMethodCalls.java')),
+            ExternalMethodsCalled().value(
+                Path(self.dir_path, 'ExternalMethodCalls.java')  # ty: ignore[invalid-argument-type]
+            ),
             2,
             'Could not calculate external methods from a file path'
         )
@@ -53,6 +55,13 @@ class ExternalMethodsCalledTest(TestCase):
             ExternalMethodsCalled().value(self._ast('LocalMethodCall.java')),
             0,
             'Could not ignore local method calls'
+        )
+
+    def test_super_method_call_is_external(self):
+        self.assertEqual(
+            ExternalMethodsCalled().value(self._ast('SuperMethodCall.java')),
+            1,
+            'Could not count super method calls as external'
         )
 
     def _ast(self, filename):

--- a/test/scripts/test_calculate_metrics.py
+++ b/test/scripts/test_calculate_metrics.py
@@ -12,8 +12,9 @@ def load_calculate_metrics_module():
         raise RuntimeError(f'Failed to load module spec from {script_path}')
     if spec.loader is None:
         raise RuntimeError(f'Failed to load module loader from {script_path}')
+    loader = spec.loader
     module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
+    loader.exec_module(module)
     return module
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Metrics can now be calculated directly from a parsed AST (with continued support for running from source files).
* **Bug Fixes**
  * Improved external method call counting so calls to locally defined methods aren’t misclassified.
  * Added correct handling for superclass (`super`) method invocations.
* **Tests**
  * Added new fixtures for local and `super` method call scenarios.
  * Updated and extended the test suite to use parsed ASTs and added a filepath-based assertion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->