### PR TITLE
#366: Count statements in variable declaration distance

### DIFF
--- a/aibolit/metrics/halsteadvolume/pom.xml
+++ b/aibolit/metrics/halsteadvolume/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
- * SPDX-License-Identifier: MIT
+SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+SPDX-License-Identifier: MIT
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0     http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>

--- a/aibolit/metrics/npath/npath.xml
+++ b/aibolit/metrics/npath/npath.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
- * SPDX-License-Identifier: MIT
+SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+SPDX-License-Identifier: MIT
 -->
 <ruleset xmlns="http://pmd.sourceforge.net/ruleset/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="quickstart" xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
   <description>Quickstart configuration of PMD. Includes the rules that are most likely to apply everywhere.</description>

--- a/aibolit/metrics/npath/pom.xml
+++ b/aibolit/metrics/npath/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
- * SPDX-License-Identifier: MIT
+SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+SPDX-License-Identifier: MIT
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>

--- a/aibolit/patterns/var_decl_diff/var_decl_diff.py
+++ b/aibolit/patterns/var_decl_diff/var_decl_diff.py
@@ -10,12 +10,11 @@ from aibolit.types_decl import LineNumber
 
 class VarDeclarationDistance:
     """
-    Returns lines where variable first time used but declared more than
-    specific number of lined before
+    Returns lines where a variable is first used far from its declaration.
     """
 
     def __init__(self, lines_th: int):
-        self.__lines_th = lines_th
+        self.__statements_th = lines_th
 
     def __node_name(self, node) -> Optional[str]:
         qualifier = node.qualifier if hasattr(node, 'qualifier') else None
@@ -23,51 +22,34 @@ class VarDeclarationDistance:
         name = node.name if hasattr(node, 'name') else None
         return qualifier or member or name
 
-    def __line_diff(self, usage_line: int, declaration_line: int, empty_lines: set[int]) -> int:
-        """
-        Calculate line difference between variable declaration and first usage
-        taking into account empty lines
-        """
-        lines_range = set(range(declaration_line + 1, usage_line))
-        return len(lines_range.difference(empty_lines))
-
-    def __find_empty_lines_in_ast(self, ast: AST) -> set[LineNumber]:
-        """Figure out lines that are either empty or multiline statements"""
-        lines_with_nodes = set()
-        ast.traverse(lambda node: lines_with_nodes.add(node.line))
-        if not lines_with_nodes:
-            return set()
-        max_line = max(lines_with_nodes)
-        all_lines = set(range(1, max_line + 1))
-        return all_lines.difference(lines_with_nodes)
-
-    def __value_for_method_declaration(
-        self, method_declaration: AST, empty_lines: set[LineNumber]
-    ) -> set[LineNumber]:
+    def __value_for_method_declaration(self, method_declaration: AST) -> set[LineNumber]:
         """Find variables declared far from their first usage in the method."""
         result = set()
-        name_to_declaration_line = {}
+        name_to_declaration_statement = {}
+        name_to_first_usage_statement = {}
         name_to_first_usage_line = {}
 
-        def collect_declaration_or_usage(node: ASTNode):
-            node_name = self.__node_name(node)
-            if node_name:
-                if node.node_type == ASTNodeType.VARIABLE_DECLARATOR:
-                    name_to_declaration_line[node_name] = node.line
-                elif (
-                    node_name in name_to_declaration_line and
-                    node_name not in name_to_first_usage_line
+        for statement_index, statement in enumerate(method_declaration.root().body or []):
+            statement_ast = method_declaration.subtree(statement)
+            for node in statement_ast.proxy_nodes(ASTNodeType.VARIABLE_DECLARATOR):
+                name_to_declaration_statement[node.name] = statement_index
+
+            def collect_usage(node: ASTNode, usage_statement: int = statement_index):
+                node_name = self.__node_name(node)
+                if (
+                    node_name in name_to_declaration_statement and
+                    node_name not in name_to_first_usage_statement and
+                    node.node_type != ASTNodeType.VARIABLE_DECLARATOR
                 ):
+                    name_to_first_usage_statement[node_name] = usage_statement
                     name_to_first_usage_line[node_name] = node.line
 
-        method_declaration.traverse(collect_declaration_or_usage)
-        for name, usage_line in name_to_first_usage_line.items():
-            line_diff = self.__line_diff(
-                usage_line,
-                name_to_declaration_line[name],
-                empty_lines,
-            )
-            if line_diff >= self.__lines_th:
+            statement_ast.traverse(collect_usage)
+
+        for name, usage_statement in name_to_first_usage_statement.items():
+            statement_diff = usage_statement - name_to_declaration_statement[name] - 1
+            if statement_diff >= self.__statements_th:
+                usage_line = name_to_first_usage_line[name]
                 result.add(usage_line)
         return result
 
@@ -75,8 +57,7 @@ class VarDeclarationDistance:
         """Find variables declared far from their first usage."""
 
         result = set()
-        empty_lines = self.__find_empty_lines_in_ast(ast)
         for declaration in ast.subtrees(ASTNodeType.METHOD_DECLARATION):
-            result.update(self.__value_for_method_declaration(declaration, empty_lines))
+            result.update(self.__value_for_method_declaration(declaration))
 
         return sorted(result)

--- a/scripts/ruleset.xml
+++ b/scripts/ruleset.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
- * SPDX-License-Identifier: MIT
+SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+SPDX-License-Identifier: MIT
 -->
 <ruleset xmlns="http://pmd.sourceforge.net/ruleset/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="quickstart" xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
   <description>Quickstart configuration of PMD. Includes the rules that are most likely to apply everywhere.</description>

--- a/test/patterns/var_decl_diff/test_var_decl_diff.py
+++ b/test/patterns/var_decl_diff/test_var_decl_diff.py
@@ -2,10 +2,12 @@
 # SPDX-License-Identifier: MIT
 
 import os
+from textwrap import dedent
 from unittest import TestCase
+
 from aibolit.ast_framework.ast import AST
 from aibolit.patterns.var_decl_diff.var_decl_diff import VarDeclarationDistance
-from aibolit.utils.ast_builder import build_ast
+from aibolit.utils.ast_builder import build_ast, build_ast_from_string
 
 
 class VarDeclarationDiffTestCase(TestCase):
@@ -30,11 +32,35 @@ class VarDeclarationDiffTestCase(TestCase):
         ast = AST.build_from_javalang(build_ast(test_file))
         pattern = VarDeclarationDistance(lines_th=5)
         lines = pattern.value(ast)
-        self.assertEqual(sorted(lines), [216, 785, 971])
+        self.assertEqual(sorted(lines), [785, 971])
 
     def test_case_with_multiline_function_arguments(self):
         test_file = os.path.join(self.cur_dir, '4.java')
         ast = AST.build_from_javalang(build_ast(test_file))
         pattern = VarDeclarationDistance(lines_th=2)
         lines = pattern.value(ast)
-        self.assertEqual(lines, [17, 21])
+        self.assertEqual(lines, [])
+
+    def test_multiline_lambda_counts_as_one_statement(self):
+        ast = AST.build_from_javalang(build_ast_from_string(dedent(
+            '''
+            class Test {
+                Object asyncCall(Object callback) {
+                    return callback;
+                }
+
+                void foo(boolean result) {
+                    final CompletableFuture<Boolean> exists = new CompletableFuture<>();
+                    asyncCall(() -> {
+                        int first = 1;
+                        int second = 2;
+                        exists.complete(result);
+                    });
+                    return exists;
+                }
+            }
+            '''
+        )))
+        pattern = VarDeclarationDistance(lines_th=2)
+        lines = pattern.value(ast)
+        self.assertEqual(lines, [])


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved variable declaration distance calculation to use statement distance instead of line distance.
  * Better handles empty and multiline statements, including multiline function arguments and lambdas, reducing incorrect matches.

* **Tests**
  * Updated and expanded var-declaration distance tests using inline AST construction utilities.
  * Adjusted expectations for multiline scenarios and added a case covering lambda statements.

* **Documentation / Chores**
  * Reformatted SPDX header comment lines consistently across related configuration and build files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->