### PR TITLE
#1296: Fix typos in P26 and P30 Java examples in PATTERNS.md

### DIFF
--- a/PATTERNS.md
+++ b/PATTERNS.md
@@ -600,7 +600,7 @@ class Book {
 
 ```java
 class Book {
-  puplic static void foo() {
+  public static void foo() {
     //something
   }
 }
@@ -720,7 +720,7 @@ class Foo {
 ```java
 class Foo {
   void foo() {
-    white (true) {
+    while (true) {
       for (;;) { // here
       }
     }


### PR DESCRIPTION
Fixed `puplic` -> `public` in P26 and `white` -> `while` in P32.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected typos in two code examples covering public static methods and nested loops.
  * Updated examples now accurately reflect their intended patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->