### PR TITLE
add P34 Return Empty String pattern

### DIFF
--- a/PATTERNS.md
+++ b/PATTERNS.md
@@ -749,3 +749,21 @@ class Foo {
 ```
 
 ***
+
+*Title*: Return Empty String
+
+*Code*: **P33**
+
+*Description*: If a return statement returns an empty string literal "" directly or via a ternary operator, it is considered a pattern.
+
+*Example*:
+
+```java
+public class Simple {
+    public String getEmpty() {
+        return "";
+    }
+}
+```
+
+***

--- a/PATTERNS.md
+++ b/PATTERNS.md
@@ -752,7 +752,7 @@ class Foo {
 
 *Title*: Return Empty String
 
-*Code*: **P33**
+*Code*: **P34**
 
 *Description*: If a return statement returns an empty string literal "" directly or via a ternary operator, it is considered a pattern.
 

--- a/PATTERNS.md
+++ b/PATTERNS.md
@@ -600,7 +600,7 @@ class Book {
 
 ```java
 class Book {
-  puplic static void foo() {
+  public static void foo() {
     //something
   }
 }
@@ -720,7 +720,7 @@ class Foo {
 ```java
 class Foo {
   void foo() {
-    white (true) {
+    while (true) {
       for (;;) { // here
       }
     }

--- a/aibolit/patterns/return_empty_string/__init__.py
+++ b/aibolit/patterns/return_empty_string/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+# SPDX-License-Identifier: MIT

--- a/aibolit/patterns/return_empty_string/return_empty_string.py
+++ b/aibolit/patterns/return_empty_string/return_empty_string.py
@@ -26,7 +26,7 @@ class ReturnEmptyString:
         if return_statement.expression is None:
             return False
 
-        # Проверяем, является ли выражение тернарным оператором (a ? b : c)
+        # Check if the expression is a ternary operator (a ? b : c)
         if return_statement.expression.node_type == ASTNodeType.TERNARY_EXPRESSION:
             return self._check_empty_string_expression(return_statement.expression.if_true) or \
                 self._check_empty_string_expression(return_statement.expression.if_false)
@@ -34,6 +34,6 @@ class ReturnEmptyString:
         return self._check_empty_string_expression(return_statement.expression)
 
     def _check_empty_string_expression(self, expression: ASTNode) -> bool:
-        # Проверяем, что это литерал и его значение строго '""'
-        # (javalang сохраняет кавычки как часть значения строки)
+        # Check that it is a literal and its value is strictly '""'
+        # (javalang preserves the quotes as part of the string value)
         return expression.node_type == ASTNodeType.LITERAL and expression.value == '""'

--- a/aibolit/patterns/return_empty_string/return_empty_string.py
+++ b/aibolit/patterns/return_empty_string/return_empty_string.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+# SPDX-License-Identifier: MIT
+
+from typing import List
+
+from aibolit.ast_framework import AST, ASTNode, ASTNodeType
+
+
+class ReturnEmptyString:
+    """
+    Finds all return statements that return an empty string literal "" directly
+    or by ternary operator.
+    NOTICE: nested ternary operators are not checked (consistent with ReturnNull).
+    """
+
+    def value(self, ast: AST) -> List[int]:
+        lines: List[int] = []
+        for return_statement in ast.proxy_nodes(ASTNodeType.RETURN_STATEMENT):
+            if self._check_empty_string_return_statement(return_statement):
+                lines.append(return_statement.line)
+
+        return lines
+
+    def _check_empty_string_return_statement(self, return_statement: ASTNode) -> bool:
+        # return statement with no expression `return;` does not return an empty string
+        if return_statement.expression is None:
+            return False
+
+        # Проверяем, является ли выражение тернарным оператором (a ? b : c)
+        if return_statement.expression.node_type == ASTNodeType.TERNARY_EXPRESSION:
+            return self._check_empty_string_expression(return_statement.expression.if_true) or \
+                self._check_empty_string_expression(return_statement.expression.if_false)
+
+        return self._check_empty_string_expression(return_statement.expression)
+
+    def _check_empty_string_expression(self, expression: ASTNode) -> bool:
+        # Проверяем, что это литерал и его значение строго '""'
+        # (javalang сохраняет кавычки как часть значения строки)
+        return expression.node_type == ASTNodeType.LITERAL and expression.value == '""'

--- a/scripts/ruleset.xml
+++ b/scripts/ruleset.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+* SPDX-License-Identifier: MIT
 -->
 <ruleset xmlns="http://pmd.sourceforge.net/ruleset/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="quickstart" xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
   <description>Quickstart configuration of PMD. Includes the rules that are most likely to apply everywhere.</description>

--- a/test/patterns/return_empty_string/Multiple.java
+++ b/test/patterns/return_empty_string/Multiple.java
@@ -1,0 +1,14 @@
+public class Multiple {
+    public String first() {
+        return "";
+    }
+
+    public String second() {
+        String x = "not empty";
+        return x;
+    }
+
+    public String third() {
+        return "";
+    }
+}

--- a/test/patterns/return_empty_string/Multiple.java
+++ b/test/patterns/return_empty_string/Multiple.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+// SPDX-License-Identifier: MIT
+
 public class Multiple {
     public String first() {
         return "";

--- a/test/patterns/return_empty_string/NotEmpty.java
+++ b/test/patterns/return_empty_string/NotEmpty.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+// SPDX-License-Identifier: MIT
+
 public class NotEmpty {
     public String getText() {
         return "Hello World";

--- a/test/patterns/return_empty_string/NotEmpty.java
+++ b/test/patterns/return_empty_string/NotEmpty.java
@@ -1,0 +1,5 @@
+public class NotEmpty {
+    public String getText() {
+        return "Hello World";
+    }
+}

--- a/test/patterns/return_empty_string/Simple.java
+++ b/test/patterns/return_empty_string/Simple.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+// SPDX-License-Identifier: MIT
+
 public class Simple {
     public String getEmpty() {
         return "";

--- a/test/patterns/return_empty_string/Simple.java
+++ b/test/patterns/return_empty_string/Simple.java
@@ -1,0 +1,5 @@
+public class Simple {
+    public String getEmpty() {
+        return "";
+    }
+}

--- a/test/patterns/return_empty_string/__init__.py
+++ b/test/patterns/return_empty_string/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+# SPDX-License-Identifier: MIT

--- a/test/patterns/return_empty_string/test_return_empty_string.py
+++ b/test/patterns/return_empty_string/test_return_empty_string.py
@@ -17,8 +17,8 @@ class ReturnEmptyStringPatternTestCase(TestCase):
         ast = AST.build_from_javalang(build_ast(filepath))
         pattern = ReturnEmptyString()
         lines = pattern.value(ast)
-        # В файле Simple.java return "" на 3-й строке
-        self.assertEqual(lines, [3])
+        # В файле Simple.java return "" на 6-й строке
+        self.assertEqual(lines, [6])
 
     def test_not_empty(self):
         filepath = self.current_directory / 'NotEmpty.java'
@@ -34,4 +34,4 @@ class ReturnEmptyStringPatternTestCase(TestCase):
         pattern = ReturnEmptyString()
         lines = pattern.value(ast)
         # В файле Multiple.java return "" на 3-й и 11-й строках
-        self.assertEqual(lines, [3, 12])
+        self.assertEqual(lines, [6, 15])

--- a/test/patterns/return_empty_string/test_return_empty_string.py
+++ b/test/patterns/return_empty_string/test_return_empty_string.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+# SPDX-License-Identifier: MIT
+
+from pathlib import Path
+from unittest import TestCase
+
+from aibolit.patterns.return_empty_string.return_empty_string import ReturnEmptyString
+from aibolit.ast_framework import AST
+from aibolit.utils.ast_builder import build_ast
+
+
+class ReturnEmptyStringPatternTestCase(TestCase):
+    current_directory = Path(__file__).absolute().parent
+
+    def test_simple(self):
+        filepath = self.current_directory / 'Simple.java'
+        ast = AST.build_from_javalang(build_ast(filepath))
+        pattern = ReturnEmptyString()
+        lines = pattern.value(ast)
+        # В файле Simple.java return "" на 3-й строке
+        self.assertEqual(lines, [3])
+
+    def test_not_empty(self):
+        filepath = self.current_directory / 'NotEmpty.java'
+        ast = AST.build_from_javalang(build_ast(filepath))
+        pattern = ReturnEmptyString()
+        lines = pattern.value(ast)
+        # В файле NotEmpty.java нет пустых строк
+        self.assertEqual(lines, [])
+
+    def test_multiple(self):
+        filepath = self.current_directory / 'Multiple.java'
+        ast = AST.build_from_javalang(build_ast(filepath))
+        pattern = ReturnEmptyString()
+        lines = pattern.value(ast)
+        # В файле Multiple.java return "" на 3-й и 11-й строках
+        self.assertEqual(lines, [3, 12])

--- a/test/patterns/return_empty_string/test_return_empty_string.py
+++ b/test/patterns/return_empty_string/test_return_empty_string.py
@@ -17,7 +17,7 @@ class ReturnEmptyStringPatternTestCase(TestCase):
         ast = AST.build_from_javalang(build_ast(filepath))
         pattern = ReturnEmptyString()
         lines = pattern.value(ast)
-        # В файле Simple.java return "" на 6-й строке
+        # In the file Simple.java, return "" on line 6
         self.assertEqual(lines, [6])
 
     def test_not_empty(self):
@@ -25,7 +25,7 @@ class ReturnEmptyStringPatternTestCase(TestCase):
         ast = AST.build_from_javalang(build_ast(filepath))
         pattern = ReturnEmptyString()
         lines = pattern.value(ast)
-        # В файле NotEmpty.java нет пустых строк
+        # The NotEmpty.java file contains no empty lines.
         self.assertEqual(lines, [])
 
     def test_multiple(self):
@@ -33,5 +33,5 @@ class ReturnEmptyStringPatternTestCase(TestCase):
         ast = AST.build_from_javalang(build_ast(filepath))
         pattern = ReturnEmptyString()
         lines = pattern.value(ast)
-        # В файле Multiple.java return "" на 3-й и 11-й строках
+        # In the Multiple.java file, return "" on lines 6 and 15.
         self.assertEqual(lines, [6, 15])


### PR DESCRIPTION
Closes #1300

This PR introduces P33 (Return Empty String), a new pattern to detect methods returning empty string literals ("").

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new Java pattern to detect `return ""` and empty-string results returned via ternary expressions.
* **Documentation**
  * Updated `PATTERNS.md` with a new “Return Empty String” section.
  * Fixed typos in existing Java example snippets.
* **Tests**
  * Added Java fixtures and unit tests for empty-string returns, ternary cases, and non-empty returns.
* **Chores**
  * Added/updated SPDX headers and XML SPDX formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->