### PR TITLE
#1302: correct XML indentation in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ mode, but xml will be created:
           <score>10.76</score>
           <order>2/4</order>
         </pattern>
-          <pattern code="P21">
+        <pattern code="P21">
           <details>Var in the middle</details>
           <lines>
             <number>235</number>
@@ -168,7 +168,7 @@ mode, but xml will be created:
           <score>2.056</score>
           <order>3/4</order>
         </pattern>
-          <pattern code="P28">
+        <pattern code="P28">
           <details>Null Assignment</details>
           <lines>
             <number>2411</number>


### PR DESCRIPTION
Fixes #1302

Corrects the missing leading spaces for the <pattern code="P21"> and <pattern code="P28"> blocks in the XML output example within README.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README’s XML output example with corrected formatting and indentation for pattern entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->