### PR TITLE
#1304: git commit -m "feat(patterns): add P35 Empty Finally Block pattern"

### DIFF
--- a/PATTERNS.md
+++ b/PATTERNS.md
@@ -749,3 +749,22 @@ class Foo {
 ```
 
 ***
+
+*Title*: Empty Finally Block
+
+*Code*: **P35**
+
+*Description*: If a try block has a finally clause that contains no statements (an empty block finally { }), it is considered a pattern.
+
+*Example*:
+
+```java
+public class Empty {
+    void test() {
+        try {
+            System.out.println("try");
+        } finally {
+        }
+    }
+}
+```

--- a/PATTERNS.md
+++ b/PATTERNS.md
@@ -768,3 +768,4 @@ public class Empty {
     }
 }
 ```
+***

--- a/aibolit/patterns/empty_finally/__init__.py
+++ b/aibolit/patterns/empty_finally/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+# SPDX-License-Identifier: MIT

--- a/aibolit/patterns/empty_finally/empty_finally.py
+++ b/aibolit/patterns/empty_finally/empty_finally.py
@@ -12,6 +12,17 @@ class EmptyFinally:
     """
 
     def value(self, ast: AST) -> List[int]:
+        """
+        Calculate line numbers of empty finally blocks in the given AST.
+
+        Args:
+            ast: The AST of the Java file to analyze.
+
+        Returns:
+            A list of line numbers where empty finally blocks are found.
+            Since the AST wrapper unwraps empty blocks, the line of the
+            parent 'try' statement is returned.
+        """
         lines: List[int] = []
         for try_statement in ast.proxy_nodes(ASTNodeType.TRY_STATEMENT):
             # Check if the 'finally' block exists for this try statement

--- a/aibolit/patterns/empty_finally/empty_finally.py
+++ b/aibolit/patterns/empty_finally/empty_finally.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+# SPDX-License-Identifier: MIT
+
+from typing import List
+
+from aibolit.ast_framework import AST, ASTNodeType
+
+
+class EmptyFinally:
+    """
+    Finds all try-catch-finally statements where the 'finally' block is empty.
+    """
+
+    def value(self, ast: AST) -> List[int]:
+        lines: List[int] = []
+        for try_statement in ast.proxy_nodes(ASTNodeType.TRY_STATEMENT):
+            # Check if the 'finally' block exists for this try statement
+            if hasattr(try_statement, 'finally_block') and try_statement.finally_block is not None:
+                block = try_statement.finally_block
+
+                # Aibolit's AST wrapper unwraps BlockStatements into lists of statements.
+                # An empty finally block is represented as an empty list [].
+                is_empty = (isinstance(block, list) and len(block) == 0) or \
+                           (hasattr(block, 'statements') and len(block.statements) == 0)
+
+                if is_empty:
+                    # Since the empty block loses its specific line number in the wrapper,
+                    # we report the line of the 'try' keyword itself.
+                    lines.append(try_statement.line)
+
+        return lines

--- a/test/patterns/empty_finally/Empty.java
+++ b/test/patterns/empty_finally/Empty.java
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+// SPDX-License-Identifier: MIT
+
+public class Empty {
+    void test() {
+        try {
+            System.out.println("try");
+        } finally {
+        }
+    }
+}

--- a/test/patterns/empty_finally/NoFinally.java
+++ b/test/patterns/empty_finally/NoFinally.java
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+// SPDX-License-Identifier: MIT
+
+public class NoFinally {
+    void test() {
+        try {
+            int x = 1;
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/test/patterns/empty_finally/NotEmpty.java
+++ b/test/patterns/empty_finally/NotEmpty.java
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+// SPDX-License-Identifier: MIT
+
+public class NotEmpty {
+    void test() {
+        try {
+            int x = 1;
+        } finally {
+            System.out.println("finally");
+        }
+    }
+}

--- a/test/patterns/empty_finally/__init__.py
+++ b/test/patterns/empty_finally/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+# SPDX-License-Identifier: MIT

--- a/test/patterns/empty_finally/test_empty_finally.py
+++ b/test/patterns/empty_finally/test_empty_finally.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+# SPDX-License-Identifier: MIT
+
+from pathlib import Path
+from unittest import TestCase
+
+from aibolit.patterns.empty_finally.empty_finally import EmptyFinally
+from aibolit.ast_framework import AST
+from aibolit.utils.ast_builder import build_ast
+
+
+class EmptyFinallyPatternTestCase(TestCase):
+    current_directory = Path(__file__).absolute().parent
+
+    def test_empty(self):
+        filepath = self.current_directory / 'Empty.java'
+        ast = AST.build_from_javalang(build_ast(filepath))
+        pattern = EmptyFinally()
+        lines = pattern.value(ast)
+        # The number of line depends on the parser.
+        self.assertEqual(lines, [6])
+
+    def test_not_empty(self):
+        filepath = self.current_directory / 'NotEmpty.java'
+        ast = AST.build_from_javalang(build_ast(filepath))
+        pattern = EmptyFinally()
+        lines = pattern.value(ast)
+        self.assertEqual(lines, [])
+
+    def test_no_finally(self):
+        filepath = self.current_directory / 'NoFinally.java'
+        ast = AST.build_from_javalang(build_ast(filepath))
+        pattern = EmptyFinally()
+        lines = pattern.value(ast)
+        self.assertEqual(lines, [])

--- a/test/patterns/empty_finally/test_empty_finally.py
+++ b/test/patterns/empty_finally/test_empty_finally.py
@@ -10,9 +10,12 @@ from aibolit.utils.ast_builder import build_ast
 
 
 class EmptyFinallyPatternTestCase(TestCase):
+    """Test cases for the EmptyFinally pattern detection."""
+
     current_directory = Path(__file__).absolute().parent
 
     def test_empty(self):
+        """Verify that an empty finally block is detected."""
         filepath = self.current_directory / 'Empty.java'
         ast = AST.build_from_javalang(build_ast(filepath))
         pattern = EmptyFinally()
@@ -21,6 +24,7 @@ class EmptyFinallyPatternTestCase(TestCase):
         self.assertEqual(lines, [6])
 
     def test_not_empty(self):
+        """Verify that a non-empty finally block is not flagged."""
         filepath = self.current_directory / 'NotEmpty.java'
         ast = AST.build_from_javalang(build_ast(filepath))
         pattern = EmptyFinally()
@@ -28,6 +32,7 @@ class EmptyFinallyPatternTestCase(TestCase):
         self.assertEqual(lines, [])
 
     def test_no_finally(self):
+        """Verify that a try/catch without finally is not flagged."""
         filepath = self.current_directory / 'NoFinally.java'
         ast = AST.build_from_javalang(build_ast(filepath))
         pattern = EmptyFinally()


### PR DESCRIPTION
Closes #1304

This PR introduces P35 (Empty Finally Block), a new pattern to detect try statements that contain empty finally blocks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an analysis pattern to detect Java `try` statements with an empty `finally {}` block and report the affected line numbers.
* **Documentation**
  * Updated pattern documentation for **P35 (Empty Finally Block)**, including an example and a minor formatting adjustment.
* **Tests**
  * Added Java fixtures and unit tests covering empty `finally`, non-empty `finally`, and missing `finally`.
* **Chores**
  * Added SPDX license headers to the new pattern and test modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->