### PR TITLE
Update tqdm to 4.69.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "scikit-learn==1.9.0",
   "scipy==1.17.1",
   "setuptools==83.0.0",
-  "tqdm==4.68.4",
+  "tqdm==4.69.0",
 ]
 
 classifiers = [


### PR DESCRIPTION
Closes #907 (обновление зависимости tqdm).

Обновил tqdm до версии 4.69.0. Все основные проверки (тесты, flake8, pylint, mypy, ruff, bandit) прошли успешно. Ошибка ty не связана с этим изменением и присутствует в текущем коде проекта.

Проверил локально: `make` завершается с ошибкой только на ty, остальное — OK.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the progress-bar component to version 4.69.0 for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->