### PR TITLE
Update pebble to 5.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
   "numpy==2.4.6",
   "packaging==26.2",        # For version parsing, updated for sphinx compatibility
   "pandas==3.0.4",
-  "pebble==5.2.0",
+  "pebble==5.2.1",
   "requests==2.34.2",
   "scikit-learn==1.9.0",
   "scipy==1.17.1",


### PR DESCRIPTION
Обновил pebble до версии 5.2.1 согласно Dependency Dashboard.
Все проверки (тесты, flake8, pylint, mypy, ruff, bandit) прошли успешно. Ошибка ty не связана с этим изменением.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Pebble runtime dependency to version 5.2.1 for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->