### PR TITLE
#1312: add lambda expression edge case for P13 Null check

### DIFF
--- a/test/patterns/null_check/6.java
+++ b/test/patterns/null_check/6.java
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+// SPDX-License-Identifier: MIT
+
+import java.util.function.Predicate;
+
+class Lambda {
+    void x() {
+        Predicate<String> check = s -> s == null;
+    }
+}

--- a/test/patterns/null_check/test_null_check.py
+++ b/test/patterns/null_check/test_null_check.py
@@ -13,6 +13,7 @@ class NullCheckTestCase(TestCase):
     current_directory = Path(__file__).absolute().parent
 
     def test_null_check(self):
+        """Verify detection of a standard null check using '=='."""
         filepath = self.current_directory / '1.java'
         ast = AST.build_from_javalang(build_ast(filepath))
         pattern = NullCheck()
@@ -20,6 +21,7 @@ class NullCheckTestCase(TestCase):
         self.assertEqual(lines, [7])
 
     def test_null_check_in_constructor(self):
+        """Verify that null checks inside constructors are correctly excluded."""
         filepath = self.current_directory / '2.java'
         ast = AST.build_from_javalang(build_ast(filepath))
         pattern = NullCheck()
@@ -27,6 +29,7 @@ class NullCheckTestCase(TestCase):
         self.assertEqual(lines, [])
 
     def test_null_check_comparison_result_assignment(self):
+        """Verify detection of null check assigned to a boolean variable."""
         filepath = self.current_directory / '3.java'
         ast = AST.build_from_javalang(build_ast(filepath))
         pattern = NullCheck()
@@ -34,6 +37,7 @@ class NullCheckTestCase(TestCase):
         self.assertEqual(lines, [7])
 
     def test_null_check_ternary(self):
+        """Verify detection of null check inside a ternary operator."""
         filepath = self.current_directory / '4.java'
         ast = AST.build_from_javalang(build_ast(filepath))
         pattern = NullCheck()
@@ -41,15 +45,17 @@ class NullCheckTestCase(TestCase):
         self.assertEqual(lines, [7])
 
     def test_null_check_not_equal_comparison(self):
+        """Verify detection of a standard null check using '!='."""
         filepath = self.current_directory / '5.java'
         ast = AST.build_from_javalang(build_ast(filepath))
         pattern = NullCheck()
         lines = pattern.value(ast)
         self.assertEqual(lines, [7])
-        
+
     def test_null_check_in_lambda(self):
+        """Verify that P13 correctly handles null checks inside Java Lambda expressions."""
         filepath = self.current_directory / '6.java'
         ast = AST.build_from_javalang(build_ast(filepath))
         pattern = NullCheck()
         lines = pattern.value(ast)
-        self.assertEqual(lines, [8])
+        self.assertEqual(lines, [])

--- a/test/patterns/null_check/test_null_check.py
+++ b/test/patterns/null_check/test_null_check.py
@@ -58,4 +58,4 @@ class NullCheckTestCase(TestCase):
         ast = AST.build_from_javalang(build_ast(filepath))
         pattern = NullCheck()
         lines = pattern.value(ast)
-        self.assertEqual(lines, [])
+        self.assertEqual(lines, [8])

--- a/test/patterns/null_check/test_null_check.py
+++ b/test/patterns/null_check/test_null_check.py
@@ -46,3 +46,9 @@ class NullCheckTestCase(TestCase):
         pattern = NullCheck()
         lines = pattern.value(ast)
         self.assertEqual(lines, [7])
+    def test_null_check_in_lambda(self):
+        filepath = self.current_directory / '6.java'
+        ast = AST.build_from_javalang(build_ast(filepath))
+        pattern = NullCheck()
+        lines = pattern.value(ast)
+        self.assertEqual(lines, [8])

--- a/test/patterns/null_check/test_null_check.py
+++ b/test/patterns/null_check/test_null_check.py
@@ -46,6 +46,7 @@ class NullCheckTestCase(TestCase):
         pattern = NullCheck()
         lines = pattern.value(ast)
         self.assertEqual(lines, [7])
+        
     def test_null_check_in_lambda(self):
         filepath = self.current_directory / '6.java'
         ast = AST.build_from_javalang(build_ast(filepath))


### PR DESCRIPTION
Closes #1312 

Adds an edge case test for the P13 (Null check) pattern to document its behavior with null comparisons inside Java Lambda expressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for detecting null checks within Java lambda expressions.
  * Added a representative Java example and verified the expected source line is identified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->