### PR TITLE
#1296: Fix typos in Java code examples

### DIFF
--- a/PATTERNS.md
+++ b/PATTERNS.md
@@ -600,7 +600,7 @@ class Book {
 
 ```java
 class Book {
-  puplic static void foo() {
+  public static void foo() {
     //something
   }
 }
@@ -720,7 +720,7 @@ class Foo {
 ```java
 class Foo {
   void foo() {
-    white (true) {
+    while (true) {
       for (;;) { // here
       }
     }


### PR DESCRIPTION
Fixes two typos in the Java examples in `PATTERNS.md`:

- replaces `puplic` with `public` in P26;
- replaces `white` with `while` in P32.

Closes #1296.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected Java examples for public static methods and nested loops.
  * Fixed syntax and keyword typos to ensure the documented patterns are accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->