### PR TITLE
feat(#1316): add P37 Empty Catch Block pattern

### DIFF
--- a/PATTERNS.md
+++ b/PATTERNS.md
@@ -749,3 +749,24 @@ class Foo {
 ```
 
 ***
+
+*Title*: Empty Catch Block
+
+*Code*: **P36**
+
+*Description*: If a try block has a catch clause that contains no statements (an empty block catch (Exception e) { }), it is considered a pattern.
+
+*Example*:
+
+```java
+public class Empty {
+    void test() {
+        try {
+            System.out.println("try");
+        } catch (Exception e) {
+        }
+    }
+}
+```
+
+***

--- a/PATTERNS.md
+++ b/PATTERNS.md
@@ -754,7 +754,7 @@ class Foo {
 
 *Code*: **P36**
 
-*Description*: If a try block has a catch clause that contains no statements (an empty block catch (Exception e) { }), it is considered a pattern.
+*Description*: If a try block has a catch clause that contains no statements (an empty catch block such as `catch (Exception e) {}`), it is considered a pattern.
 
 *Example*:
 

--- a/PATTERNS.md
+++ b/PATTERNS.md
@@ -771,7 +771,7 @@ class Foo {
 
 *Title*: Empty Finally Block
 
-*Code*: **P34**
+*Code*: **P35**
 
 *Description*: If a try block has a finally clause that contains no statements (an empty block finally { }), it is considered a pattern.
 
@@ -792,7 +792,7 @@ public class Empty {
 
 *Title*: Return Empty String
 
-*Code*: **P35**
+*Code*: **P36**
 
 *Description*: If a return statement returns an empty string literal "" directly or in either branch of a single-level ternary operator, it is considered a pattern. Nested ternary operators are not checked.
 
@@ -808,7 +808,7 @@ public class Simple {
 
 *Title*: Empty Catch Block
 
-*Code*: **P36**
+*Code*: **P37**
 
 *Description*: If a try block has a catch clause that contains no statements (an empty catch block such as `catch (Exception e) {}`), it is considered a pattern.
 

--- a/aibolit/patterns/empty_catch/__init__.py
+++ b/aibolit/patterns/empty_catch/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+# SPDX-License-Identifier: MIT

--- a/aibolit/patterns/empty_catch/empty_catch.py
+++ b/aibolit/patterns/empty_catch/empty_catch.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+# SPDX-License-Identifier: MIT
+
+from typing import List
+
+from aibolit.ast_framework import AST, ASTNodeType
+
+
+class EmptyCatch:
+    """
+    Finds all try-catch statements where the 'catch' block is empty.
+    """
+
+    def value(self, ast: AST) -> List[int]:
+        """
+        Calculate line numbers of empty catch blocks in the given AST.
+
+        Args:
+            ast: The AST of the Java file to analyze.
+
+        Returns:
+            A list of line numbers where empty catch blocks are found.
+            Since the AST wrapper unwraps empty blocks, the line of the
+            parent 'try' statement is returned.
+        """
+        lines: List[int] = []
+        for try_statement in ast.proxy_nodes(ASTNodeType.TRY_STATEMENT):
+            # Check if the 'catches' list exists and is not empty
+            if hasattr(try_statement, 'catches') and try_statement.catches:
+                for catch_clause in try_statement.catches:
+                    # In javalang, the body of a catch clause is stored in the 'block' attribute
+                    block = getattr(catch_clause, 'block', None)
+
+                    # An empty catch block is represented as an empty list []
+                    if block is not None and isinstance(block, list) and len(block) == 0:
+                        # Report the line of the 'try' statement
+                        lines.append(try_statement.line)
+
+        return lines

--- a/test/patterns/empty_catch/Empty.java
+++ b/test/patterns/empty_catch/Empty.java
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+// SPDX-License-Identifier: MIT
+
+public class Empty {
+    void test() {
+        try {
+            System.out.println("try");
+        } catch (Exception e) {
+        }
+    }
+}

--- a/test/patterns/empty_catch/NoCatch.java
+++ b/test/patterns/empty_catch/NoCatch.java
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+// SPDX-License-Identifier: MIT
+
+public class NoCatch {
+    void test() {
+        try {
+            int x = 1;
+        } finally {
+            System.out.println("finally");
+        }
+    }
+}

--- a/test/patterns/empty_catch/NotEmpty.java
+++ b/test/patterns/empty_catch/NotEmpty.java
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+// SPDX-License-Identifier: MIT
+
+public class NotEmpty {
+    void test() {
+        try {
+            System.out.println("try");
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/test/patterns/empty_catch/test_empty_catch.py
+++ b/test/patterns/empty_catch/test_empty_catch.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+# SPDX-License-Identifier: MIT
+
+from pathlib import Path
+from unittest import TestCase
+
+from aibolit.patterns.empty_catch.empty_catch import EmptyCatch
+from aibolit.ast_framework import AST
+from aibolit.utils.ast_builder import build_ast
+
+
+class EmptyCatchPatternTestCase(TestCase):
+    """
+    Test cases for the P36 (Empty Catch Block) pattern.
+    """
+    current_directory = Path(__file__).absolute().parent
+
+    def test_empty(self):
+        """
+        Verify that an empty catch block is detected.
+        The parser returns the line of the 'try' keyword (line 6).
+        """
+        filepath = self.current_directory / 'Empty.java'
+        ast = AST.build_from_javalang(build_ast(filepath))
+        pattern = EmptyCatch()
+        lines = pattern.value(ast)
+        self.assertEqual(lines, [6])
+
+    def test_not_empty(self):
+        """
+        Verify that a catch block with statements is ignored.
+        """
+        filepath = self.current_directory / 'NotEmpty.java'
+        ast = AST.build_from_javalang(build_ast(filepath))
+        pattern = EmptyCatch()
+        lines = pattern.value(ast)
+        self.assertEqual(lines, [])
+
+    def test_no_catch(self):
+        """
+        Verify that a try-finally block without a catch clause is ignored.
+        """
+        filepath = self.current_directory / 'NoCatch.java'
+        ast = AST.build_from_javalang(build_ast(filepath))
+        pattern = EmptyCatch()
+        lines = pattern.value(ast)
+        self.assertEqual(lines, [])


### PR DESCRIPTION
Closes #1316

This PR introduces P37 (Empty Catch Block), a new pattern to detect try statements that contain empty catch blocks (exception swallowing).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added detection for empty Java `catch` blocks and report the line numbers where they occur.
* **Documentation**
  * Documented the new “Empty Catch Block” pattern (P37).
  * Updated “Empty Finally Block” documentation and adjusted subsequent pattern numbering/formatting.
* **Tests**
  * Added Java fixtures and unit tests covering empty `catch`, non-empty `catch`, and `try-finally` without `catch`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->