### PR TITLE
fix: avoid direct import of os.sched_getaffinity

### DIFF
--- a/scripts/04-find-patterns.py
+++ b/scripts/04-find-patterns.py
@@ -7,13 +7,11 @@ from concurrent.futures import TimeoutError
 from csv import DictWriter, QUOTE_MINIMAL
 from functools import partial
 from logging import basicConfig, INFO, warning
+import os
 from os import cpu_count, getenv, makedirs
-try:
-    from os import sched_getaffinity
-except ImportError:
-    MAYBE_ON_MACOS = True
-else:
-    MAYBE_ON_MACOS = False
+
+sched_getaffinity = getattr(os, "sched_getaffinity", None)
+MAYBE_ON_MACOS = sched_getaffinity is None
 from pathlib import Path
 from sys import stderr
 from typing import Any, Dict, List

--- a/scripts/04-find-patterns.py
+++ b/scripts/04-find-patterns.py
@@ -21,11 +21,11 @@ from aibolit.config import Config
 from aibolit.ast_framework import AST, ASTNodeType
 from aibolit.ast_framework.java_class_decomposition import decompose_java_class
 from aibolit.utils.ast_builder import build_ast
-
 sched_getaffinity = getattr(os, "sched_getaffinity", None)
 MAYBE_ON_MACOS = sched_getaffinity is None
 
-class FileProcessingError(RuntimeError):
+
+class FileProcessingError(RuntimeError)::
     def __init__(self, filepath: str, pattern_name: str, cause: Exception):
         super().__init__(f'Failed calculating {pattern_name} on file {filepath}.\nReason: {cause}')
 

--- a/scripts/04-find-patterns.py
+++ b/scripts/04-find-patterns.py
@@ -6,16 +6,13 @@ from collections import defaultdict
 from concurrent.futures import TimeoutError
 from csv import DictWriter, QUOTE_MINIMAL
 from functools import partial
-from logging import basicConfig, INFO, warning
+from logging import INFO, basicConfig, warning
+import json
 import os
 from os import cpu_count, getenv, makedirs
-
-sched_getaffinity = getattr(os, "sched_getaffinity", None)
-MAYBE_ON_MACOS = sched_getaffinity is None
 from pathlib import Path
 from sys import stderr
 from typing import Any, Dict, List
-import json
 
 from pebble import ProcessPool
 from tqdm import tqdm
@@ -25,6 +22,8 @@ from aibolit.ast_framework import AST, ASTNodeType
 from aibolit.ast_framework.java_class_decomposition import decompose_java_class
 from aibolit.utils.ast_builder import build_ast
 
+sched_getaffinity = getattr(os, "sched_getaffinity", None)
+MAYBE_ON_MACOS = sched_getaffinity is None
 
 class FileProcessingError(RuntimeError):
     def __init__(self, filepath: str, pattern_name: str, cause: Exception):

--- a/scripts/04-find-patterns.py
+++ b/scripts/04-find-patterns.py
@@ -25,7 +25,7 @@ sched_getaffinity = getattr(os, "sched_getaffinity", None)
 MAYBE_ON_MACOS = sched_getaffinity is None
 
 
-class FileProcessingError(RuntimeError)::
+class FileProcessingError(RuntimeError):
     def __init__(self, filepath: str, pattern_name: str, cause: Exception):
         super().__init__(f'Failed calculating {pattern_name} on file {filepath}.\nReason: {cause}')
 


### PR DESCRIPTION
Fixes #1320
Replace the direct import of `os.sched_getaffinity` with `getattr()`.

This avoids the `unresolved-import` diagnostic reported by `ty` on platforms where `sched_getaffinity` is unavailable while preserving the existing behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved platform compatibility by adjusting how CPU affinity support is detected when system APIs are unavailable.
  * Preserved existing CPU core handling behavior on platforms without CPU affinity support, avoiding incorrect capability assumptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->