### PR TITLE
#349: Implement non final argument pattern

### DIFF
--- a/PATTERNS.md
+++ b/PATTERNS.md
@@ -642,6 +642,23 @@ class MyList extends AbstractList { // here
 ```
 
 ***
+
+*Title*: Non final argument
+
+*Code*: **P35**
+
+*Description*: Once a method or constructor argument is not declared as `final`, it's a pattern.
+
+*Example*:
+
+```java
+class Book {
+  void read(String title) { // here
+  }
+}
+```
+
+***
 *Title*: Assign null
 
 *Code*: **P28**

--- a/aibolit/config.py
+++ b/aibolit/config.py
@@ -43,6 +43,7 @@ from aibolit.patterns.method_chaining.method_chaining import MethodChainFind as 
 from aibolit.patterns.multiple_try.multiple_try import MultipleTry as P11
 from aibolit.patterns.multiple_while.multiple_while import MultipleWhile as P29
 from aibolit.patterns.nested_blocks.nested_blocks import NestedBlocks as P32
+from aibolit.patterns.non_final_argument.non_final_argument import NonFinalArgument as P35
 from aibolit.patterns.non_final_attribute.non_final_attribute import NonFinalAttribute as P12
 from aibolit.patterns.non_final_class.non_final_class import NonFinalClass as P24
 from aibolit.patterns.null_check.null_check import NullCheck as P13
@@ -200,6 +201,7 @@ class Config(metaclass=Singleton):
                                      ASTNodeType.WHILE_STATEMENT)},
                 {'name': 'Incomplete For', 'code': 'P33', 'make': P33},
                 {'name': 'Class inheritance', 'code': 'P34', 'make': P34},
+                {'name': 'Non final argument', 'code': 'P35', 'make': P35},
             ],
             'metrics': [
                 {'name': 'Entropy', 'code': 'M1', 'make': M1},  # type: ignore

--- a/aibolit/metrics/halsteadvolume/pom.xml
+++ b/aibolit/metrics/halsteadvolume/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
- * SPDX-License-Identifier: MIT
+SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+SPDX-License-Identifier: MIT
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0     http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>

--- a/aibolit/metrics/npath/npath.xml
+++ b/aibolit/metrics/npath/npath.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
- * SPDX-License-Identifier: MIT
+SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+SPDX-License-Identifier: MIT
 -->
 <ruleset xmlns="http://pmd.sourceforge.net/ruleset/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="quickstart" xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
   <description>Quickstart configuration of PMD. Includes the rules that are most likely to apply everywhere.</description>

--- a/aibolit/metrics/npath/pom.xml
+++ b/aibolit/metrics/npath/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
- * SPDX-License-Identifier: MIT
+SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+SPDX-License-Identifier: MIT
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>

--- a/aibolit/patterns/non_final_argument/non_final_argument.py
+++ b/aibolit/patterns/non_final_argument/non_final_argument.py
@@ -1,32 +1,24 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
 # SPDX-License-Identifier: MIT
-import os
-from typing import Iterator
+from typing import List
 
 from aibolit.ast_framework import AST, ASTNodeType
 from aibolit.types_decl import LineNumber
-from aibolit.utils.ast_builder import build_ast
 
 
 class NonFinalArgument:
-    def __init__(self):
-        pass
-
-    def value(self, filename: str | os.PathLike) -> list[LineNumber]:
+    def value(self, ast: AST) -> list[LineNumber]:
         """
-        Returns the line numbers of the file name which contains no final arguments
+        Returns line numbers of methods and constructors with non-final arguments.
 
-        :param filename: name of the file
+        :param ast: AST to inspect
         :return: number of the lines with non-final arguments
         """
-        return sorted(_offending_lines(AST.build_from_javalang(build_ast(filename))))
-
-
-def _offending_lines(ast: AST) -> Iterator[LineNumber]:
-    for node in ast.proxy_nodes(
-        ASTNodeType.METHOD_DECLARATION,
-        ASTNodeType.CONSTRUCTOR_DECLARATION,
-    ):
-        for parameter in node.parameters:
-            if 'final' not in parameter.modifiers:
-                yield node.line
+        lines: List[LineNumber] = []
+        for node in ast.proxy_nodes(
+            ASTNodeType.METHOD_DECLARATION,
+            ASTNodeType.CONSTRUCTOR_DECLARATION,
+        ):
+            if any('final' not in parameter.modifiers for parameter in node.parameters):
+                lines.append(node.line)
+        return lines

--- a/scripts/ruleset.xml
+++ b/scripts/ruleset.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
- * SPDX-License-Identifier: MIT
+SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+SPDX-License-Identifier: MIT
 -->
 <ruleset xmlns="http://pmd.sourceforge.net/ruleset/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="quickstart" xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
   <description>Quickstart configuration of PMD. Includes the rules that are most likely to apply everywhere.</description>

--- a/test/patterns/non_final_argument/test_non_final_argument.py
+++ b/test/patterns/non_final_argument/test_non_final_argument.py
@@ -5,7 +5,9 @@ import os
 from pathlib import Path
 from unittest import TestCase
 
+from aibolit.ast_framework import AST
 from aibolit.patterns.non_final_argument.non_final_argument import NonFinalArgument
+from aibolit.utils.ast_builder import build_ast
 
 
 class NonFinalArgumentTestCase(TestCase):
@@ -13,10 +15,13 @@ class NonFinalArgumentTestCase(TestCase):
 
     def test_find_non_final_argument_in_ctor(self):
         self.assertEqual(
-            NonFinalArgument().value(Path(self.dir_path, 'NonFinalArgumentCtor.java')), [10]
+            NonFinalArgument().value(self._ast('NonFinalArgumentCtor.java')), [10]
         )
 
     def test_find_non_final_argument_in_method(self):
         self.assertEqual(
-            NonFinalArgument().value(Path(self.dir_path, 'NonFinalArgumentMethod.java')), [14]
+            NonFinalArgument().value(self._ast('NonFinalArgumentMethod.java')), [14]
         )
+
+    def _ast(self, filename):
+        return AST.build_from_javalang(build_ast(Path(self.dir_path, filename)))

--- a/test/stats/results_test.csv
+++ b/test/stats/results_test.csv
@@ -1,37 +1,38 @@
 ,pattern, -1(top1),+1(top1),p-c-,p+c+,p-c+,p+c-,p-c=,p+c=
-0,Asserts,1,6,1,1,8,8,0,0
-1,Setters,0,0,1,2,9,8,0,0
-2,Empty Rethrow,0,0,1,2,9,8,0,0
-3,Prohibited class name,0,0,1,2,9,8,0,0
-4,Force Type Casting,0,0,1,2,9,8,0,0
-5,Count If Return,0,0,1,2,9,8,0,0
-6,Implements Multi,0,0,1,2,9,8,0,0
-7,Instance of,0,0,1,2,9,8,0,0
-8,Many primary constructors,0,0,1,2,9,8,0,0
-9,Method chain,0,0,1,2,9,8,0,0
-10,Multiple try,0,0,1,2,9,8,0,0
-11,Non final attribute,0,0,1,2,9,8,0,0
-12,Null check,0,0,1,2,9,8,0,0
-13,Partial synchronized,0,0,1,2,9,8,0,0
-14,Redundant catch,0,0,1,2,9,8,0,0
-15,Return null,0,0,1,2,9,8,0,0
-16,String concat,0,0,1,2,9,8,0,0
-17,Super Method,0,0,1,2,9,8,0,0
-18,This in constructor,0,0,1,2,9,8,0,0
-19,Var declaration distance for 5 lines,0,0,1,2,9,8,0,0
-20,Var declaration distance for 7 lines,0,0,1,2,9,8,0,0
-21,Var declaration distance for 11 lines,0,0,1,2,9,8,0,0
-22,Var in the middle,0,0,1,2,9,8,0,0
-23,Array as function argument,0,0,1,2,9,8,0,0
-24,Joined validation,0,0,1,2,9,8,0,0
-25,Non final class,0,0,1,2,9,8,0,0
-26,Private static method,0,0,1,2,9,8,0,0
-27,Public static method,0,0,1,2,9,8,0,0
-28,Var siblings,0,0,1,2,9,8,0,0
-29,Null Assignment,0,1,1,2,9,8,0,0
-30,Multiple While,0,0,1,2,9,8,0,0
-31,Protected Method,0,0,1,2,9,8,0,0
-32,Send Null,0,0,1,2,9,8,0,0
-33,Nested Loop,0,0,1,2,9,8,0,0
-34,Incomplete For,0,1,1,2,9,8,0,0
-35,Class inheritance,0,0,1,2,9,8,0,0
+0,Asserts,1,7,1,1,8,8,0,0
+1,Setters,1,0,2,2,8,8,0,0
+2,Empty Rethrow,0,0,2,2,8,8,0,0
+3,Prohibited class name,0,0,2,2,8,8,0,0
+4,Force Type Casting,0,0,2,2,8,8,0,0
+5,Count If Return,0,0,2,2,8,8,0,0
+6,Implements Multi,0,0,2,2,8,8,0,0
+7,Instance of,0,0,2,2,8,8,0,0
+8,Many primary constructors,0,0,2,2,8,8,0,0
+9,Method chain,0,0,2,2,8,8,0,0
+10,Multiple try,0,0,2,2,8,8,0,0
+11,Non final attribute,0,0,2,2,8,8,0,0
+12,Null check,0,0,2,2,8,8,0,0
+13,Partial synchronized,0,0,2,2,8,8,0,0
+14,Redundant catch,0,0,2,2,8,8,0,0
+15,Return null,0,0,2,2,8,8,0,0
+16,String concat,0,0,2,2,8,8,0,0
+17,Super Method,0,0,2,2,8,8,0,0
+18,This in constructor,0,0,2,2,8,8,0,0
+19,Var declaration distance for 5 lines,0,0,2,2,8,8,0,0
+20,Var declaration distance for 7 lines,0,0,2,2,8,8,0,0
+21,Var declaration distance for 11 lines,0,0,2,2,8,8,0,0
+22,Var in the middle,0,0,2,2,8,8,0,0
+23,Array as function argument,0,0,2,2,8,8,0,0
+24,Joined validation,0,0,2,2,8,8,0,0
+25,Non final class,0,0,2,2,8,8,0,0
+26,Private static method,0,0,2,2,8,8,0,0
+27,Public static method,0,0,2,2,8,8,0,0
+28,Var siblings,0,0,2,2,8,8,0,0
+29,Null Assignment,0,0,2,2,8,8,0,0
+30,Multiple While,0,0,2,2,8,8,0,0
+31,Protected Method,0,0,2,2,8,8,0,0
+32,Send Null,0,0,2,2,8,8,0,0
+33,Nested Loop,0,0,2,2,8,8,0,0
+34,Incomplete For,0,1,2,2,8,8,0,0
+35,Class inheritance,0,0,2,2,8,8,0,0
+36,Non final argument,0,0,2,2,8,8,0,0


### PR DESCRIPTION
Replacement for #1283, submitted from @marinka-aa. The branch contains the same head commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the **Non final argument (P35)** pattern for detecting methods and constructors with parameters missing the `final` modifier.
  - Registered the pattern so it is available through configuration-based tooling.

- **Documentation**
  - Added guidance and a Java example for the new pattern.

- **Refactor**
  - Improved pattern processing to work with parsed source trees for more consistent analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->