### PR TITLE
#1300 Add P35 pattern for returning empty string literals ()

### DIFF
--- a/PATTERNS.md
+++ b/PATTERNS.md
@@ -749,3 +749,21 @@ class Foo {
 ```
 
 ***
+
+*Title*: Return Empty String
+
+*Code*: **P35**
+
+*Description*: If a return statement returns an empty string literal "" directly or via a ternary operator, it is considered a pattern.
+
+*Example*:
+
+```java
+public class Simple {
+    public String getEmpty() {
+        return "";
+    }
+}
+```
+
+***

--- a/PATTERNS.md
+++ b/PATTERNS.md
@@ -754,7 +754,7 @@ class Foo {
 
 *Code*: **P35**
 
-*Description*: If a return statement returns an empty string literal "" directly or via a ternary operator, it is considered a pattern.
+*Description*: If a return statement returns an empty string literal "" directly or in either branch of a single-level ternary operator, it is considered a pattern. Nested ternary operators are not checked.
 
 *Example*:
 

--- a/aibolit/patterns/return_empty_string/__init__.py
+++ b/aibolit/patterns/return_empty_string/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+# SPDX-License-Identifier: MIT

--- a/aibolit/patterns/return_empty_string/return_empty_string.py
+++ b/aibolit/patterns/return_empty_string/return_empty_string.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+# SPDX-License-Identifier: MIT
+
+from typing import List
+
+from aibolit.ast_framework import AST, ASTNode, ASTNodeType
+
+
+class ReturnEmptyString:
+    """
+    Finds all return statements that return an empty string literal "" directly
+    or by ternary operator.
+    NOTICE: nested ternary operators are not checked (consistent with ReturnNull).
+    """
+
+    def value(self, ast: AST) -> List[int]:
+        lines: List[int] = []
+        for return_statement in ast.proxy_nodes(ASTNodeType.RETURN_STATEMENT):
+            if self._check_empty_string_return_statement(return_statement):
+                lines.append(return_statement.line)
+
+        return lines
+
+    def _check_empty_string_return_statement(self, return_statement: ASTNode) -> bool:
+        """
+        Check if a return statement returns an empty string,
+        including via a single-level ternary operator.
+        """
+        # return statement with no expression `return;` does not return an empty string
+        if return_statement.expression is None:
+            return False
+        # Check if the expression is a ternary operator (a ? b : c)
+        if return_statement.expression.node_type == ASTNodeType.TERNARY_EXPRESSION:
+            return self._check_empty_string_expression(return_statement.expression.if_true) or \
+                self._check_empty_string_expression(return_statement.expression.if_false)
+        return self._check_empty_string_expression(return_statement.expression)
+
+    def _check_empty_string_expression(self, expression: ASTNode) -> bool:
+        """
+        Check that the expression is a string literal strictly equal to '""'.
+        (javalang preserves the quotes as part of the string value).
+        """
+        return expression.node_type == ASTNodeType.LITERAL and expression.value == '""'

--- a/test/patterns/return_empty_string/Multiple.java
+++ b/test/patterns/return_empty_string/Multiple.java
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+// SPDX-License-Identifier: MIT
+
+public class Multiple {
+    public String first() {
+        return "";
+    }
+
+    public String second() {
+        String x = "not empty";
+        return x;
+    }
+
+    public String third() {
+        return "";
+    }
+    
+    // Added to cover ternary operator with empty strings in both branches
+    public String ternaryBothEmpty(boolean condition) {
+        return condition ? "" : "";
+    }
+}

--- a/test/patterns/return_empty_string/NotEmpty.java
+++ b/test/patterns/return_empty_string/NotEmpty.java
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+// SPDX-License-Identifier: MIT
+
+public class NotEmpty {
+    public String getText() {
+        return "Hello World";
+    }
+}

--- a/test/patterns/return_empty_string/Simple.java
+++ b/test/patterns/return_empty_string/Simple.java
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+// SPDX-License-Identifier: MIT
+
+public class Simple {
+    public String getEmpty() {
+        return "";
+    }
+}

--- a/test/patterns/return_empty_string/__init__.py
+++ b/test/patterns/return_empty_string/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+# SPDX-License-Identifier: MIT

--- a/test/patterns/return_empty_string/test_return_empty_string.py
+++ b/test/patterns/return_empty_string/test_return_empty_string.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
+# SPDX-License-Identifier: MIT
+
+from pathlib import Path
+from unittest import TestCase
+
+from aibolit.patterns.return_empty_string.return_empty_string import ReturnEmptyString
+from aibolit.ast_framework import AST
+from aibolit.utils.ast_builder import build_ast
+
+
+class ReturnEmptyStringPatternTestCase(TestCase):
+    """
+    Test cases for the P33 (Return Empty String) pattern.
+    """
+    current_directory = Path(__file__).absolute().parent
+
+    def test_simple(self):
+        """
+        Verify that a simple 'return "";' statement is detected.
+        """
+        filepath = self.current_directory / 'Simple.java'
+        ast = AST.build_from_javalang(build_ast(filepath))
+        pattern = ReturnEmptyString()
+        lines = pattern.value(ast)
+        # In the file Simple.java, return "" on line 6
+        self.assertEqual(lines, [6])
+
+    def test_not_empty(self):
+        """
+        Verify that a return statement with a normal string is ignored.
+        """
+        filepath = self.current_directory / 'NotEmpty.java'
+        ast = AST.build_from_javalang(build_ast(filepath))
+        pattern = ReturnEmptyString()
+        lines = pattern.value(ast)
+        # The NotEmpty.java file contains no empty strings.
+        self.assertEqual(lines, [])
+
+    def test_multiple(self):
+        """
+        Verify that multiple empty string returns in one file are all detected.
+        """
+        filepath = self.current_directory / 'Multiple.java'
+        ast = AST.build_from_javalang(build_ast(filepath))
+        pattern = ReturnEmptyString()
+        lines = pattern.value(ast)
+        # In the Multiple.java file, return "" on lines 6, 15, 20.
+        self.assertEqual(lines, [6, 15, 20])

--- a/test/patterns/return_empty_string/test_return_empty_string.py
+++ b/test/patterns/return_empty_string/test_return_empty_string.py
@@ -11,7 +11,7 @@ from aibolit.utils.ast_builder import build_ast
 
 class ReturnEmptyStringPatternTestCase(TestCase):
     """
-    Test cases for the P33 (Return Empty String) pattern.
+    Test cases for the P35 (Return Empty String) pattern.
     """
     current_directory = Path(__file__).absolute().parent
 


### PR DESCRIPTION
Closes #1300

This PR introduces P35 (Return Empty String), a new pattern to detect methods returning empty string literals ("").

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new “Return Empty String” pattern that detects Java methods returning the empty string literal (`""`), including simple ternary forms.
  * Updated pattern documentation to describe the new rule (P35).
* **Tests**
  * Added unit tests covering single matches, no matches, multiple matches, and ternary return scenarios.
* **Chores**
  * Added SPDX license headers to related pattern and test modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->