### PR TITLE
Reorder documented patterns by P-code and fix P27 formatting

### DIFF
--- a/PATTERNS.md
+++ b/PATTERNS.md
@@ -609,7 +609,7 @@ class Book {
 ***
 *Title*: Var siblings
 
-*Code*: **27**
+*Code*: **P27**
 
 *Description*: Here fileSize and fileDate are "siblings" because they both have file as first part of their compound names. It's better to rename them to size and date.
 
@@ -625,23 +625,8 @@ class Foo {
   }
 }
 ```
-
 ***
 
-*Title*: Class inheritance
-
-*Code*: **P34**
-
-*Description*: Once a class extends another class via `extends`, it's a pattern.
-
-*Example*:
-
-```java
-class MyList extends AbstractList { // here
-}
-```
-
-***
 *Title*: Assign null
 
 *Code*: **P28**
@@ -745,6 +730,21 @@ class Foo {
       ++i;
     }
   }
+}
+```
+
+***
+
+*Title*: Class inheritance
+
+*Code*: **P34**
+
+*Description*: Once a class extends another class via `extends`, it's a pattern.
+
+*Example*:
+
+```java
+class MyList extends AbstractList { // here
 }
 ```
 


### PR DESCRIPTION
## Summary

This PR improves the organization of `PATTERNS.md` by making the documented pattern list more consistent.

### Changes
- reordered documented pattern entries to follow ascending P-code order;
- fixed the `Var siblings` pattern code formatting from `**27**` to `**P27**`;
- left pattern descriptions and examples unchanged.

Documentation only. No functional changes.
Closes #1333

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved pattern documentation formatting and section spacing.
  * Standardized the “Var siblings” pattern identifier to P27.
  * Updated and reformatted the “Class inheritance” pattern documentation, including its example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->