### PR TITLE
fix(#1340): avoid duplicate findings after applying ignore ranges

### DIFF
--- a/aibolit/__main__.py
+++ b/aibolit/__main__.py
@@ -36,7 +36,6 @@ from aibolit.ast_framework import AST, ASTNodeType
 from aibolit.ast_framework.java_class_decomposition import decompose_java_class
 from aibolit.config import Config, Metric
 from aibolit.metrics.ncss.ncss import NCSSMetric
-from aibolit.ml_pipeline.ml_pipeline import train_process, collect_dataset
 from aibolit.utils.ast_builder import build_ast
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
@@ -116,6 +115,8 @@ def train():
              'Default is cognitive.'
     )
     args = parser.parse_args(sys.argv[2:])
+    from aibolit.ml_pipeline.ml_pipeline import collect_dataset, train_process
+
     if not args.skip_collect_dataset:
         collect_dataset(args)
 
@@ -172,19 +173,22 @@ def add_pattern_if_ignored(
     """
     ignored_lines = dct.get(pattern_item['pattern_code'])
     if ignored_lines:
+        remaining_code_lines = pattern_item['code_lines']
         for place in ignored_lines:
             # get lines range of ignored code
             start_line_to_ignore = place[0]
             end_line_to_ignore = place[1]
             new_code_lines = []
-            for line in pattern_item['code_lines']:
+            for line in remaining_code_lines:
                 if start_line_to_ignore <= line <= end_line_to_ignore:
                     continue
                 else:
                     new_code_lines.append(line)
-            pattern_item['code_lines'] = new_code_lines
-            if len(pattern_item['code_lines']) > 0:
-                results_list.append(pattern_item)
+            remaining_code_lines = new_code_lines
+        if remaining_code_lines:
+            updated_item = dict(pattern_item)
+            updated_item['code_lines'] = remaining_code_lines
+            results_list.append(updated_item)
     else:
         results_list.append(pattern_item)
 

--- a/test/recommend/test_recommend_pipeline.py
+++ b/test/recommend/test_recommend_pipeline.py
@@ -365,6 +365,17 @@ class TestRecommendPipeline(TestCase):
         add_pattern_if_ignored(pattern_ignored, pattern_item, results)
         self.assertEqual(results[0]['code_lines'], pattern_item['code_lines'])
 
+    def test_pattern_ignore_with_multiple_ranges_does_not_duplicate_result(self):
+        pattern_item = {'code_lines': [20, 30],
+                        'pattern_code': 'P14',
+                        'pattern_name': 'Null check',
+                        'importance': 30.95612931128819}
+        results = []
+        pattern_ignored = {'P14': [[1, 10], [40, 50]]}
+        add_pattern_if_ignored(pattern_ignored, pattern_item, results)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]['code_lines'], [20, 30])
+
     def test_process_components_deduplicates_class_level_findings(self):
         # A class-level pattern (e.g. P4 "Prohibited class name") re-fires in
         # every decomposed component, reporting the same line repeatedly with


### PR DESCRIPTION
Closes #1340
## Why

`add_pattern_if_ignored()` may append the same finding multiple times when
a pattern has more than one ignore range.

## What

- apply all ignore ranges first
- append the finding once after filtering is complete
- keep the original behavior for findings without ignore ranges

## Result

Recommendation output no longer contains duplicated findings created by
ignore-range processing.

## How it was verified

- added a regression test for multiple ignore ranges

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed duplicate recommendations when multiple ignored line ranges apply to the same pattern.
  - Preserved the original finding details while filtering ignored lines.
  - Improved reliability of the training command by loading its processing components only when needed.

- **Tests**
  - Added coverage to verify that findings are recorded once and ignored ranges are handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->