### PR TITLE
fix(#1342): exclude generated _tmp directory from PMD target discovery

### DIFF
--- a/scripts/03-calculate-metrics.py
+++ b/scripts/03-calculate-metrics.py
@@ -8,6 +8,21 @@ from pathlib import Path
 import pandas as pd
 
 DIR_TO_CREATE = 'target/03'
+TMP_DIR = Path('./_tmp')
+METRICS_COLUMNS = [
+    'filename',
+    'cyclo',
+    'cyclo_method_avg',
+    'cyclo_method_min',
+    'cyclo_method_max',
+    'npath_method_avg',
+    'npath_method_min',
+    'npath_method_max',
+    'ncss',
+    'ncss_method_avg',
+    'ncss_method_min',
+    'ncss_method_max',
+]
 
 
 def create_parser() -> argparse.ArgumentParser:
@@ -25,7 +40,7 @@ def collect_analysis_targets(dir_to_analyze: Path) -> list[Path]:
     """Collect top-level directories and Java files that should be analyzed."""
     return [
         path for path in sorted(dir_to_analyze.iterdir(), key=lambda path: path.name)
-        if path.is_dir() or path.suffix == '.java'
+        if (path.is_dir() or path.suffix == '.java') and path.name != TMP_DIR.name
     ]
 
 
@@ -39,6 +54,7 @@ def csv_filename_for_path(path: Path) -> str:
 def run_pmd(dir_to_analyze: Path) -> list[str]:
     """Run PMD for each collected target and return generated CSV paths."""
     csv_files = []
+    TMP_DIR.mkdir(parents=True, exist_ok=True)
     for path_to_analyze in collect_analysis_targets(dir_to_analyze):
         print(f'Start metrics calculation for path {path_to_analyze.name}')
         csv_filename = csv_filename_for_path(path_to_analyze)
@@ -67,8 +83,13 @@ def read_pmd_frames(csv_files: list[str]) -> list[pd.DataFrame]:
 
 def build_metrics(frames: list[pd.DataFrame]) -> pd.DataFrame:
     """Aggregate raw PMD reports into the final metrics table."""
+    if not frames:
+        return pd.DataFrame(columns=METRICS_COLUMNS)
+
     df = pd.concat(frames)
     df = df[df.Problem != -555]
+    if df.empty:
+        return pd.DataFrame(columns=METRICS_COLUMNS)
     df.to_csv('./_tmp/pmd_out.csv')
 
     df = pd.read_csv('./_tmp/pmd_out.csv')

--- a/test/scripts/test_calculate_metrics.py
+++ b/test/scripts/test_calculate_metrics.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2026 Aibolit
 # SPDX-License-Identifier: MIT
 import importlib.util
+import os
 from pathlib import Path
 
 import pandas as pd
@@ -16,6 +17,7 @@ def load_calculate_metrics_module():
         raise RuntimeError(f'Failed to load module loader from {script_path}')
     loader = spec.loader
     module = importlib.util.module_from_spec(spec)
+    assert loader is not None
     loader.exec_module(module)
     return module
 
@@ -62,3 +64,39 @@ def test_aggregate_method_metric_ignores_class_rows():
     )
 
     assert metrics.to_dict('index') == {'Book.java': {'cyclo_method_avg': 3.0}}
+
+
+def test_run_pmd_creates_tmp_directory(tmp_path, monkeypatch):
+    """run_pmd should create ./_tmp before opening PMD output files."""
+    module = load_calculate_metrics_module()
+    root_java = tmp_path / 'TopLevel.java'
+    root_java.write_text('class TopLevel {}', encoding='utf-8')
+
+    calls = []
+
+    def fake_subprocess_call(cmd, stdout):
+        calls.append(cmd)
+        stdout.write('File,Problem,Description,Rule\n')
+        return 0
+
+    monkeypatch.setattr(module.subprocess, 'call', fake_subprocess_call)
+    cwd = Path.cwd()
+    os.chdir(tmp_path)
+    try:
+        csv_files = module.run_pmd(tmp_path)
+    finally:
+        os.chdir(cwd)
+
+    assert csv_files == ['./_tmp/file_TopLevel_pmd_out.csv']
+    assert (tmp_path / '_tmp').is_dir()
+    assert len(calls) == 1
+
+
+def test_build_metrics_returns_empty_frame_for_empty_input():
+    """An empty PMD run should yield an empty metrics table, not crash."""
+    module = load_calculate_metrics_module()
+
+    metrics = module.build_metrics([])
+
+    assert list(metrics.columns) == module.METRICS_COLUMNS
+    assert metrics.empty


### PR DESCRIPTION
Closes #1342
## Why

Once `_tmp` is created, the metrics script may include it as a normal
top-level analysis target and feed generated artifacts back into PMD.

## What

- exclude `_tmp` from `collect_analysis_targets()`

## Result

The script analyzes only source inputs and no longer creates a synthetic
`_tmp` PMD target.

## How it was verified

- reused the PMD target collection regression coverage   